### PR TITLE
Global depth-sorted draw across multiple GsplatRenderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added optional global depth sorting across multiple GsplatRenderer instances, allowing splats from different renderers to interleave correctly in a single draw call. An option `Enable Global Sort` is added to `Project Settings > Gsplat` to enable this feature. Global sorting only supports assets with Spark compression. The package falls back to the per-renderer pipeline when any active `GsplatRenderer` using an uncompressed asset. ([#28](https://github.com/wuyize25/gsplat-unity/pull/28) by [@KeirRice](https://github.com/KeirRice))
+
 ## [1.3.0] - 2026-05-23
 
 ### Added

--- a/Editor/GsplatRendererEditor.cs
+++ b/Editor/GsplatRendererEditor.cs
@@ -19,8 +19,9 @@ namespace Gsplat.Editor
                 && rendererTargetEarly.GsplatAsset.Compression == CompressionMode.Uncompressed)
             {
                 EditorGUILayout.HelpBox(
-                    "Global sort is enabled, but this renderer uses an uncompressed asset and " +
-                    "will not participate in the unified depth-sorted draw. Re-import with Spark " +
+                    "Global sort is enabled, but this renderer uses an uncompressed asset. " +
+                    "Global sort is all-or-nothing: if any active renderer is uncompressed, the " +
+                    "whole scene falls back to per-renderer rendering. Re-import with Spark " +
                     "compression to enable cross-renderer depth ordering.",
                     MessageType.Warning);
             }

--- a/Editor/GsplatRendererEditor.cs
+++ b/Editor/GsplatRendererEditor.cs
@@ -13,6 +13,18 @@ namespace Gsplat.Editor
         {
             serializedObject.Update();
 
+            var rendererTargetEarly = (GsplatRenderer)target;
+            if (GsplatSettings.Instance.EnableGlobalSort
+                && rendererTargetEarly.GsplatAsset
+                && rendererTargetEarly.GsplatAsset.Compression == CompressionMode.Uncompressed)
+            {
+                EditorGUILayout.HelpBox(
+                    "Global sort is enabled, but this renderer uses an uncompressed asset and " +
+                    "will not participate in the unified depth-sorted draw. Re-import with Spark " +
+                    "compression to enable cross-renderer depth ordering.",
+                    MessageType.Warning);
+            }
+
             DrawPropertiesExcluding(serializedObject, "m_Script",
                 nameof(GsplatRenderer.SHDegree),
                 nameof(GsplatRenderer.AsyncUpload),

--- a/Editor/GsplatSettingsProvider.cs
+++ b/Editor/GsplatSettingsProvider.cs
@@ -42,9 +42,9 @@ namespace Gsplat.Editor
             if (enableGlobalSortProp.boolValue)
             {
                 EditorGUILayout.HelpBox(
-                    "Only Spark-compressed assets participate in the unified depth sort. " +
-                    "Renderers using uncompressed assets fall back to per-renderer sorting and " +
-                    "may not interleave correctly with the merged draw.",
+                    "Global sort requires every active renderer to use Spark compression. " +
+                    "If any active renderer uses an uncompressed asset, global sort is disabled " +
+                    "for the whole scene and all renderers fall back to per-renderer rendering.",
                     MessageType.Info);
                 EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.GlobalMaterial)));
             }

--- a/Editor/GsplatSettingsProvider.cs
+++ b/Editor/GsplatSettingsProvider.cs
@@ -34,6 +34,21 @@ namespace Gsplat.Editor
             EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.DisplayBoundingBoxes)));
             EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.ShowImportErrors)));
             EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.Materials)));
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Global Sort", EditorStyles.boldLabel);
+            var enableGlobalSortProp = m_gsplatSettings.FindProperty(nameof(GsplatSettings.EnableGlobalSort));
+            EditorGUILayout.PropertyField(enableGlobalSortProp);
+            if (enableGlobalSortProp.boolValue)
+            {
+                EditorGUILayout.HelpBox(
+                    "Only Spark-compressed assets participate in the unified depth sort. " +
+                    "Renderers using uncompressed assets fall back to per-renderer sorting and " +
+                    "may not interleave correctly with the merged draw.",
+                    MessageType.Info);
+                EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.GlobalMaterial)));
+            }
+
             EditorGUILayout.Space();
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();

--- a/Runtime/GsplatGlobalMaterial.cs
+++ b/Runtime/GsplatGlobalMaterial.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Keir Rice
+// SPDX-License-Identifier: MIT
+
+using UnityEngine;
+
+namespace Gsplat
+{
+    [CreateAssetMenu(menuName = "Gsplat/Gsplat Global Material")]
+    public class GsplatGlobalMaterial : ScriptableObject
+    {
+        public Material DefaultMaterial;
+        public ComputeShader MergeShader;
+        public ComputeShader CopyBufferShader;
+
+        Material[] m_materials; // indexed by SH band (0–4)
+
+        /// <summary>
+        /// Returns five Material instances — one per SH band level — with the appropriate
+        /// SH_BANDS_N keyword pre-enabled. Lazily allocated and cached.
+        /// </summary>
+        public Material[] Materials
+        {
+            get
+            {
+                if (m_materials != null && m_materials[0] != null)
+                    return m_materials;
+
+                m_materials = new Material[5];
+                for (int i = 0; i < 5; i++)
+                {
+                    m_materials[i] = new Material(DefaultMaterial);
+                    m_materials[i].DisableKeyword("SH_BANDS_0");
+                    m_materials[i].DisableKeyword("SH_BANDS_1");
+                    m_materials[i].DisableKeyword("SH_BANDS_2");
+                    m_materials[i].DisableKeyword("SH_BANDS_3");
+                    m_materials[i].DisableKeyword("SH_BANDS_4");
+                    m_materials[i].EnableKeyword($"SH_BANDS_{i}");
+                }
+                return m_materials;
+            }
+        }
+
+        public void Reset() => m_materials = null;
+    }
+}

--- a/Runtime/GsplatGlobalMaterial.cs
+++ b/Runtime/GsplatGlobalMaterial.cs
@@ -36,10 +36,13 @@ namespace Gsplat
                     m_materials[i].DisableKeyword("SH_BANDS_4");
                     m_materials[i].EnableKeyword($"SH_BANDS_{i}");
                 }
+
                 return m_materials;
             }
         }
 
         public void Reset() => m_materials = null;
+
+        public bool Valid() => MergeShader && CopyBufferShader && DefaultMaterial;
     }
 }

--- a/Runtime/GsplatGlobalMaterial.cs.meta
+++ b/Runtime/GsplatGlobalMaterial.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6

--- a/Runtime/GsplatGlobalRenderer.cs
+++ b/Runtime/GsplatGlobalRenderer.cs
@@ -1,0 +1,555 @@
+﻿// Copyright (c) 2026 Keir Rice, Yize Wu
+// SPDX-License-Identifier: MIT
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace Gsplat
+{
+    public class GsplatGlobalRenderer
+    {
+        // -----------------------------------------------------------------------
+        // Global merge state
+        // -----------------------------------------------------------------------
+        GsplatGlobalMaterial m_globalMaterial;
+
+        int m_kernelPackOrders = -1;
+        int m_kernelMergeTwo = -1;
+        int m_kernelMergeTwoWithDepth = -1;
+        int m_kernelCopyUint4 = -1;
+        int m_kernelCopyUint2 = -1;
+
+        // CPU-side per-renderer metadata (rebuilt when renderers change).
+        uint[] m_rendererOffsets; // splat start index in global buffers, per active renderer
+        uint[] m_builtSplatCounts; // per-renderer SplatCount captured when the global buffers were last built
+        uint m_totalSplatCount;
+        uint m_totalRemainingCount; // sum of RemainingCounts; valid entries in GlobalOrderBuffer after merge
+        byte m_globalSHBands;
+        bool m_globalBuffersDirty = true;
+
+        // Global packed data buffers (sub-ranges owned by each renderer).
+        GraphicsBuffer m_globalPackedBuffer;
+        GraphicsBuffer m_globalSH1Buffer;
+        GraphicsBuffer m_globalSH2Buffer;
+        GraphicsBuffer m_globalSH3Buffer;
+        GraphicsBuffer m_globalSH4Buffer;
+        GraphicsBuffer m_globalOrderBuffer;
+        GraphicsBuffer m_rendererOffsetsBuffer;
+        GraphicsBuffer m_rendererTransformsBuffer;
+        GraphicsBuffer m_rendererParamsBuffer;
+
+        // Per-renderer visual settings, looked up by renderer_id during the merged draw.
+        // Matches the RendererParams struct in GsplatSparkGlobal.hlsl (16-byte stride).
+        struct RendererParams
+        {
+            public float brightness;
+            public float scaleFactor;
+            public uint gammaToLinear;
+            public uint shDegree;
+        }
+
+        // Scratch buffers for merge passes.
+        // m_packScratch*  : all renderers' orders+depths packed and concatenated.
+        // m_mergeScratch* : ping-pong pair for cascaded intermediate merges.
+        GraphicsBuffer m_packScratchOrders;
+        GraphicsBuffer m_packScratchDepths;
+        GraphicsBuffer m_mergeScratchOrders;
+        GraphicsBuffer m_mergeScratchDepths;
+        Matrix4x4[] m_rendererTransformsCache;
+        RendererParams[] m_rendererParamsCache;
+        MaterialPropertyBlock m_globalPropertyBlock;
+
+        public bool Valid => m_globalMaterial
+                             && m_globalMaterial.Valid()
+                             && m_kernelPackOrders >= 0
+                             && m_kernelMergeTwo >= 0
+                             && m_kernelMergeTwoWithDepth >= 0
+                             && m_kernelCopyUint4 >= 0
+                             && m_kernelCopyUint2 >= 0;
+
+        static readonly ProfilingSampler k_samplerMerge = new("Gsplat.MergeKWay");
+        static readonly ProfilingSampler k_samplerDraw = new("Gsplat.DrawAll");
+
+        // -----------------------------------------------------------------------
+        // Shader property IDs — merge / pack
+        // -----------------------------------------------------------------------
+        static readonly int k_rawOrders = Shader.PropertyToID("_RawOrders");
+        static readonly int k_rawDepths = Shader.PropertyToID("_RawDepths");
+        static readonly int k_packedOrders = Shader.PropertyToID("_PackedOrders");
+        static readonly int k_packedDepths = Shader.PropertyToID("_PackedDepths");
+        static readonly int k_rendererIdx = Shader.PropertyToID("_RendererIdx");
+        static readonly int k_srcCount = Shader.PropertyToID("_SrcCount");
+        static readonly int k_dstOffset = Shader.PropertyToID("_DstOffset");
+
+        static readonly int k_depthsA = Shader.PropertyToID("_DepthsA");
+        static readonly int k_ordersA = Shader.PropertyToID("_OrdersA");
+        static readonly int k_depthsB = Shader.PropertyToID("_DepthsB");
+        static readonly int k_ordersB = Shader.PropertyToID("_OrdersB");
+        static readonly int k_offsetA = Shader.PropertyToID("_OffsetA");
+        static readonly int k_offsetB = Shader.PropertyToID("_OffsetB");
+        static readonly int k_countA = Shader.PropertyToID("_CountA");
+        static readonly int k_countB = Shader.PropertyToID("_CountB");
+        static readonly int k_outputOffset = Shader.PropertyToID("_OutputOffset");
+        static readonly int k_outputOrders = Shader.PropertyToID("_OutputOrders");
+        static readonly int k_outputDepths = Shader.PropertyToID("_OutputDepths");
+
+        // Copy kernel IDs
+        static readonly int k_srcUint4 = Shader.PropertyToID("_SrcUint4");
+        static readonly int k_dstUint4 = Shader.PropertyToID("_DstUint4");
+        static readonly int k_srcUint2 = Shader.PropertyToID("_SrcUint2");
+        static readonly int k_dstUint2 = Shader.PropertyToID("_DstUint2");
+        static readonly int k_srcElementCount = Shader.PropertyToID("_SrcElementCount");
+        static readonly int k_dstElementOffset = Shader.PropertyToID("_DstElementOffset");
+
+        // Global draw material properties
+        static readonly int k_globalOrderBuffer = Shader.PropertyToID("_GlobalOrderBuffer");
+        static readonly int k_globalPackedBuffer = Shader.PropertyToID("_GlobalPackedBuffer");
+        static readonly int k_globalSH1Buffer = Shader.PropertyToID("_GlobalSH1Buffer");
+        static readonly int k_globalSH2Buffer = Shader.PropertyToID("_GlobalSH2Buffer");
+        static readonly int k_globalSH3Buffer = Shader.PropertyToID("_GlobalSH3Buffer");
+        static readonly int k_globalSH4Buffer = Shader.PropertyToID("_GlobalSH4Buffer");
+        static readonly int k_rendererOffsetsProp = Shader.PropertyToID("_RendererOffsets");
+        static readonly int k_rendererTransformsProp = Shader.PropertyToID("_RendererTransforms");
+        static readonly int k_rendererParamsProp = Shader.PropertyToID("_RendererParams");
+        static readonly int k_totalSplatCount = Shader.PropertyToID("_TotalSplatCount");
+        static readonly int k_splatInstanceSize = Shader.PropertyToID("_SplatInstanceSize");
+
+        public void InitGlobal(GsplatGlobalMaterial globalMaterial)
+        {
+            m_globalMaterial = globalMaterial;
+            m_kernelPackOrders = -1;
+            m_kernelMergeTwo = -1;
+            m_kernelMergeTwoWithDepth = -1;
+            m_kernelCopyUint4 = -1;
+            m_kernelCopyUint2 = -1;
+
+            var mergeShader = globalMaterial ? globalMaterial.MergeShader : null;
+            var copyShader = globalMaterial ? globalMaterial.CopyBufferShader : null;
+
+            if (mergeShader)
+            {
+                if (!mergeShader.HasKernel("PackRendererOrders"))
+                    Debug.LogError(
+                        $"[GsplatSorter] MergeShader '{mergeShader.name}' is missing kernel 'PackRendererOrders' — assign GsplatMergeOrderBuffers.compute.");
+                else
+                {
+                    m_kernelPackOrders = mergeShader.FindKernel("PackRendererOrders");
+                    m_kernelMergeTwo = mergeShader.FindKernel("MergeTwo");
+                    m_kernelMergeTwoWithDepth = mergeShader.FindKernel("MergeTwoWithDepth");
+                }
+            }
+
+            if (copyShader)
+            {
+                if (!copyShader.HasKernel("CopyUint4"))
+                    Debug.LogError(
+                        $"[GsplatSorter] CopyBufferShader '{copyShader.name}' is missing kernel 'CopyUint4' — assign GsplatCopyBuffer.compute.");
+                else
+                {
+                    m_kernelCopyUint4 = copyShader.FindKernel("CopyUint4");
+                    m_kernelCopyUint2 = copyShader.FindKernel("CopyUint2");
+                }
+            }
+
+            m_globalBuffersDirty = true;
+        }
+
+        public void Dispatch(CommandBuffer cmd, List<IGsplat> activeGsplats)
+        {
+            cmd.BeginSample(k_samplerMerge.name);
+            EnsureGlobalBuffers(cmd, activeGsplats);
+            // If EnsureGlobalBuffers failed (uncompressed asset, >255 renderers, etc.),
+            // m_globalOrderBuffer is null.
+            if (m_globalOrderBuffer == null)
+            {
+                cmd.EndSample(k_samplerMerge.name);
+                return;
+            }
+
+            UpdateRendererTransforms(activeGsplats);
+            UpdateRendererParams(activeGsplats);
+            DispatchMerge(cmd, activeGsplats);
+            cmd.EndSample(k_samplerMerge.name);
+        }
+
+        // -----------------------------------------------------------------------
+        // Global buffer management
+        // -----------------------------------------------------------------------
+        void EnsureGlobalBuffers(CommandBuffer cmd, List<IGsplat> activeGsplats)
+        {
+            // A renderer streaming in its splats via async upload (AsyncUpload +
+            // RenderBeforeUploadComplete) grows its SplatCount frame to frame. Rebuild when an
+            // active renderer's count no longer matches what we last built with, otherwise the
+            // global sub-ranges keep only the splats present at the first build and the rest are
+            // never copied in (leaving the merge to read stale/under-sized global buffers).
+            if (!m_globalBuffersDirty && ActiveSplatCountsChanged(activeGsplats))
+                m_globalBuffersDirty = true;
+
+            if (!m_globalBuffersDirty) return;
+            m_globalBuffersDirty = false;
+
+            DisposeGlobalBuffers();
+
+            m_totalSplatCount = 0;
+            m_rendererOffsets = new uint[activeGsplats.Count];
+            m_builtSplatCounts = new uint[activeGsplats.Count];
+            // Size SH buffers to the highest band count in the set; lower-band renderers
+            // occupy the extra slots but never read them, since each renderer's SHDegree is
+            // clamped to its own asset bands in UpdateRendererParams.
+            m_globalSHBands = 0;
+
+            foreach (var gs in activeGsplats)
+                if (gs.SHBands > m_globalSHBands)
+                    m_globalSHBands = gs.SHBands;
+
+            for (int k = 0; k < activeGsplats.Count; k++)
+            {
+                uint count = activeGsplats[k].SplatCount;
+                m_rendererOffsets[k] = m_totalSplatCount;
+                m_builtSplatCounts[k] = count;
+                m_totalSplatCount += count;
+            }
+
+            if (m_totalSplatCount == 0) return;
+
+            // CanRenderGlobally() in Gather already guarded count<=255 and Spark-only;
+            // GlobalRenderEnabled would be false and we wouldn't be here otherwise.
+
+            var st = GraphicsBuffer.Target.Structured;
+            m_globalPackedBuffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4)
+                { name = "Gsplat.GlobalPacked" };
+            m_globalOrderBuffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))
+                { name = "Gsplat.GlobalOrder" };
+            m_rendererOffsetsBuffer = new GraphicsBuffer(st, activeGsplats.Count, sizeof(uint))
+                { name = "Gsplat.RendererOffsets" };
+            m_rendererTransformsBuffer = new GraphicsBuffer(st, activeGsplats.Count, sizeof(float) * 16)
+                { name = "Gsplat.RendererTransforms" };
+            m_rendererParamsBuffer = new GraphicsBuffer(st, activeGsplats.Count, sizeof(float) * 2 + sizeof(uint) * 2)
+                { name = "Gsplat.RendererParams" };
+
+            if (m_globalSHBands >= 1)
+                m_globalSH1Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 2)
+                    { name = "Gsplat.GlobalSH1" };
+            if (m_globalSHBands >= 2)
+                m_globalSH2Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4)
+                    { name = "Gsplat.GlobalSH2" };
+            if (m_globalSHBands >= 3)
+                m_globalSH3Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4)
+                    { name = "Gsplat.GlobalSH3" };
+            if (m_globalSHBands >= 4)
+                m_globalSH4Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4)
+                    { name = "Gsplat.GlobalSH4" };
+
+            m_rendererOffsetsBuffer.SetData(m_rendererOffsets);
+
+            // Copy per-renderer packed splat data into global buffer sub-ranges.
+            for (int k = 0; k < activeGsplats.Count; k++)
+            {
+                var gs = activeGsplats[k];
+                var count = gs.SplatCount;
+                var off = m_rendererOffsets[k];
+                if (count == 0) continue;
+
+                var res = (GsplatResourceSpark)gs.GsplatResource;
+
+                CopyUint4(cmd, res.PackedSplatsBuffer, m_globalPackedBuffer, count, off);
+                if (m_globalSHBands >= 1 && res.PackedSH1Buffer != null)
+                    CopyUint2(cmd, res.PackedSH1Buffer, m_globalSH1Buffer, count, off);
+                if (m_globalSHBands >= 2 && res.PackedSH2Buffer != null)
+                    CopyUint4(cmd, res.PackedSH2Buffer, m_globalSH2Buffer, count, off);
+                if (m_globalSHBands >= 3 && res.PackedSH3Buffer != null)
+                    CopyUint4(cmd, res.PackedSH3Buffer, m_globalSH3Buffer, count, off);
+                if (m_globalSHBands >= 4 && res.PackedSH4Buffer != null)
+                    CopyUint4(cmd, res.PackedSH4Buffer, m_globalSH4Buffer, count, off);
+            }
+
+            // Allocate merge scratch buffers (always fresh after a dirty rebuild).
+            m_packScratchOrders = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))
+                { name = "Gsplat.PackScratchOrders" };
+            m_packScratchDepths = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(float))
+                { name = "Gsplat.PackScratchDepths" };
+            m_mergeScratchOrders = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))
+                { name = "Gsplat.MergeScratchOrders" };
+            m_mergeScratchDepths = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(float))
+                { name = "Gsplat.MergeScratchDepths" };
+        }
+
+        // True when an active renderer's SplatCount no longer matches what the global buffers were
+        // built with (e.g. an async upload has streamed in more splats since the last rebuild).
+        // Active-set size changes are already covered by MarkGlobalBuffersDirty on register/unregister.
+        bool ActiveSplatCountsChanged(List<IGsplat> activeGsplats)
+        {
+            if (m_builtSplatCounts == null || m_builtSplatCounts.Length != activeGsplats.Count)
+                return true;
+            return activeGsplats.Where((t, k) => m_builtSplatCounts[k] != t.SplatCount).Any();
+        }
+
+        void UpdateRendererTransforms(List<IGsplat> activeGsplats)
+        {
+            if (m_rendererTransformsBuffer == null) return;
+            int count = activeGsplats.Count;
+            if (m_rendererTransformsCache == null || m_rendererTransformsCache.Length != count)
+                m_rendererTransformsCache = new Matrix4x4[count];
+            for (int k = 0; k < count; k++)
+                m_rendererTransformsCache[k] = activeGsplats[k].transform.localToWorldMatrix;
+            m_rendererTransformsBuffer.SetData(m_rendererTransformsCache);
+        }
+
+        void UpdateRendererParams(List<IGsplat> activeGsplats)
+        {
+            if (m_rendererParamsBuffer == null) return;
+            int count = activeGsplats.Count;
+            if (m_rendererParamsCache == null || m_rendererParamsCache.Length != count)
+                m_rendererParamsCache = new RendererParams[count];
+            for (int k = 0; k < count; k++)
+            {
+                var gs = activeGsplats[k] as GsplatRenderer;
+                if (gs != null)
+                {
+                    m_rendererParamsCache[k] = new RendererParams
+                    {
+                        brightness = gs.Brightness,
+                        scaleFactor = 1.0f - gs.SplatDownscaleFactor,
+                        gammaToLinear = gs.GammaToLinear ? 1u : 0u,
+                        // Clamp to the asset's own bands so EvalSH never reads slots that
+                        // weren't copied for this renderer (the global buffers are sized to
+                        // the max bands across the set).
+                        shDegree = (uint)Mathf.Min(gs.SHDegree, activeGsplats[k].SHBands),
+                    };
+                }
+                else
+                {
+                    m_rendererParamsCache[k] = new RendererParams
+                    {
+                        brightness = 1.0f,
+                        scaleFactor = 1.0f,
+                        gammaToLinear = 0u,
+                        shDegree = activeGsplats[k].SHBands,
+                    };
+                }
+            }
+
+            m_rendererParamsBuffer.SetData(m_rendererParamsCache);
+        }
+
+        // -----------------------------------------------------------------------
+        // Copy helpers (GPU-side via command buffer)
+        // -----------------------------------------------------------------------
+        void CopyUint4(CommandBuffer cmd, GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
+        {
+            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_srcElementCount, (int)count);
+            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_dstElementOffset, (int)dstOff);
+            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, k_srcUint4, src);
+            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, k_dstUint4, dst);
+            cmd.DispatchCompute(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4,
+                (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
+        }
+
+        void CopyUint2(CommandBuffer cmd, GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
+        {
+            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_srcElementCount, (int)count);
+            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_dstElementOffset, (int)dstOff);
+            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, k_srcUint2, src);
+            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, k_dstUint2, dst);
+            cmd.DispatchCompute(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2,
+                (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
+        }
+
+        // -----------------------------------------------------------------------
+        // Merge dispatch
+        // -----------------------------------------------------------------------
+        void DispatchMerge(CommandBuffer cmd, List<IGsplat> activeGsplats)
+        {
+            int K = activeGsplats.Count;
+            if (K < 2 || m_globalOrderBuffer == null) return;
+
+            // Step 1: pack each renderer's sorted orders + depths into m_packScratch.
+            for (int k = 0; k < K; k++)
+            {
+                var gs = activeGsplats[k];
+                if (gs.SorterResource is not { } res) continue;
+                uint cnt = gs.RemainingCount;
+                uint off = m_rendererOffsets[k];
+                if (cnt == 0) continue;
+
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_rendererIdx, k);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_srcCount, (int)cnt);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_dstOffset, (int)off);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_rawOrders,
+                    res.OrderBuffer);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_rawDepths, res.InputKeys);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_packedOrders,
+                    m_packScratchOrders);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_packedDepths,
+                    m_packScratchDepths);
+                cmd.DispatchCompute(m_globalMaterial.MergeShader, m_kernelPackOrders,
+                    (int)GsplatUtils.DivRoundUp(cnt, 256), 1, 1);
+            }
+
+            // Step 2: cascaded 2-way merges.
+            // After each pass the merged sub-range grows. We alternate writing between
+            // m_packScratch (treated as read-only source) and m_mergeScratch.
+            // Source for renderer k's sorted range is always m_packScratchOrders[off[k]..off[k]+cnt[k]).
+            // The merged-so-far result alternates between m_mergeScratch and a temporary swap.
+
+            uint mergedCount = activeGsplats[0].RemainingCount; // size of merged result so far
+            uint mergedOffset = 0; // always at start of its scratch buffer
+
+            // Current merged result lives in: packScratch initially (range [0, mergedCount)).
+            // We swap between packScratch and mergeScratch each pass.
+            bool mergedInPack = true;
+
+            for (int k = 1; k < K; k++)
+            {
+                var gs = activeGsplats[k];
+                uint cntK = gs.RemainingCount;
+                uint offK = m_rendererOffsets[k];
+                bool isFinal = (k == K - 1);
+                uint total = mergedCount + cntK;
+
+                // Source A: current merged result.
+                var srcAOrders = mergedInPack ? m_packScratchOrders : m_mergeScratchOrders;
+                var srcADepths = mergedInPack ? m_packScratchDepths : m_mergeScratchDepths;
+
+                // Source B: renderer k's range in packScratch.
+                // (always in packScratch regardless of which buffer holds merged result)
+                var srcBOrders = m_packScratchOrders;
+                var srcBDepths = m_packScratchDepths;
+
+                // Destination: final pass → globalOrderBuffer; otherwise the other scratch.
+                GraphicsBuffer dstOrders, dstDepths;
+                if (isFinal)
+                {
+                    dstOrders = m_globalOrderBuffer;
+                    dstDepths = null;
+                }
+                else
+                {
+                    dstOrders = mergedInPack ? m_mergeScratchOrders : m_packScratchOrders;
+                    dstDepths = mergedInPack ? m_mergeScratchDepths : m_packScratchDepths;
+                }
+
+                int kernel = isFinal ? m_kernelMergeTwo : m_kernelMergeTwoWithDepth;
+
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_offsetA, (int)mergedOffset);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_offsetB, (int)offK);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_countA, (int)mergedCount);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_countB, (int)cntK);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_outputOffset, 0);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_depthsA, srcADepths);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_ordersA, srcAOrders);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_depthsB, srcBDepths);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_ordersB, srcBOrders);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_outputOrders, dstOrders);
+                if (!isFinal)
+                    cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_outputDepths, dstDepths);
+
+                cmd.DispatchCompute(m_globalMaterial.MergeShader, kernel, (int)GsplatUtils.DivRoundUp(total, 256), 1,
+                    1);
+
+                mergedCount = total;
+                mergedOffset = 0; // output always starts at 0 in the destination buffer
+                mergedInPack = !mergedInPack;
+            }
+
+            m_totalRemainingCount = mergedCount;
+        }
+
+        // -----------------------------------------------------------------------
+        // Global draw call
+        // -----------------------------------------------------------------------
+
+
+        public void DrawAll(CommandBuffer cmd, Camera camera)
+        {
+            // m_globalBuffersDirty: the active renderer set changed and the next DispatchSort
+            // hasn't validated/rebuilt the buffers yet. Drawing now would bind stale buffers
+            // (under URP, DrawAllIfEnabled fires before DispatchSort each frame).
+            if (m_globalBuffersDirty || m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
+
+            cmd?.BeginSample(k_samplerDraw.name);
+
+            var mat = m_globalMaterial.Materials[m_globalSHBands];
+
+            // Bind buffers via a MaterialPropertyBlock rather than on the material itself, so
+            // each queued draw captures its own bindings and multiple cameras (Game + SceneView,
+            // or any multi-camera setup) don't overwrite one another's state before the GPU
+            // executes them.
+            m_globalPropertyBlock ??= new MaterialPropertyBlock();
+            m_globalPropertyBlock.Clear();
+            m_globalPropertyBlock.SetBuffer(k_globalOrderBuffer, m_globalOrderBuffer);
+            m_globalPropertyBlock.SetBuffer(k_globalPackedBuffer, m_globalPackedBuffer);
+            m_globalPropertyBlock.SetBuffer(k_rendererOffsetsProp, m_rendererOffsetsBuffer);
+            m_globalPropertyBlock.SetBuffer(k_rendererTransformsProp, m_rendererTransformsBuffer);
+            m_globalPropertyBlock.SetBuffer(k_rendererParamsProp, m_rendererParamsBuffer);
+            m_globalPropertyBlock.SetInteger(k_totalSplatCount, (int)m_totalRemainingCount);
+            m_globalPropertyBlock.SetInteger(k_splatInstanceSize, (int)GsplatSettings.Instance.SplatInstanceSize);
+
+            if (m_globalSH1Buffer != null)
+                m_globalPropertyBlock.SetBuffer(k_globalSH1Buffer, m_globalSH1Buffer);
+            if (m_globalSH2Buffer != null)
+                m_globalPropertyBlock.SetBuffer(k_globalSH2Buffer, m_globalSH2Buffer);
+            if (m_globalSH3Buffer != null)
+                m_globalPropertyBlock.SetBuffer(k_globalSH3Buffer, m_globalSH3Buffer);
+            if (m_globalSH4Buffer != null)
+                m_globalPropertyBlock.SetBuffer(k_globalSH4Buffer, m_globalSH4Buffer);
+
+            var rp = new RenderParams(mat)
+            {
+                worldBounds = new Bounds(Vector3.zero, Vector3.one * 1e6f),
+                camera = camera,
+                matProps = m_globalPropertyBlock
+            };
+
+            int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            Graphics.RenderMeshPrimitives(rp, GsplatSettings.Instance.Mesh, 0, instances);
+
+            cmd?.EndSample(k_samplerDraw.name);
+        }
+
+
+        // -----------------------------------------------------------------------
+        // Cleanup
+        // -----------------------------------------------------------------------
+        public void DisposeGlobalBuffers()
+        {
+            m_globalPackedBuffer?.Dispose();
+            m_globalPackedBuffer = null;
+            m_globalSH1Buffer?.Dispose();
+            m_globalSH1Buffer = null;
+            m_globalSH2Buffer?.Dispose();
+            m_globalSH2Buffer = null;
+            m_globalSH3Buffer?.Dispose();
+            m_globalSH3Buffer = null;
+            m_globalSH4Buffer?.Dispose();
+            m_globalSH4Buffer = null;
+            m_globalOrderBuffer?.Dispose();
+            m_globalOrderBuffer = null;
+            m_rendererOffsetsBuffer?.Dispose();
+            m_rendererOffsetsBuffer = null;
+            m_rendererTransformsBuffer?.Dispose();
+            m_rendererTransformsBuffer = null;
+            m_rendererParamsBuffer?.Dispose();
+            m_rendererParamsBuffer = null;
+            // Scratch buffers are rebuilt every time global buffers are rebuilt,
+            // so dispose them here too to avoid leaking when renderer count shrinks.
+            m_packScratchOrders?.Dispose();
+            m_packScratchOrders = null;
+            m_packScratchDepths?.Dispose();
+            m_packScratchDepths = null;
+            m_mergeScratchOrders?.Dispose();
+            m_mergeScratchOrders = null;
+            m_mergeScratchDepths?.Dispose();
+            m_mergeScratchDepths = null;
+            // Drop the build snapshot so the next EnsureGlobalBuffers re-captures counts from scratch.
+            m_builtSplatCounts = null;
+        }
+
+        /// <summary>
+        /// Call when a renderer's asset changes so the global packed buffer is rebuilt next frame.
+        /// </summary>
+        public void MarkGlobalBuffersDirty() => m_globalBuffersDirty = true;
+    }
+}

--- a/Runtime/GsplatGlobalRenderer.cs
+++ b/Runtime/GsplatGlobalRenderer.cs
@@ -10,9 +10,6 @@ namespace Gsplat
 {
     public class GsplatGlobalRenderer
     {
-        // -----------------------------------------------------------------------
-        // Global merge state
-        // -----------------------------------------------------------------------
         GsplatGlobalMaterial m_globalMaterial;
 
         int m_kernelPackOrders = -1;
@@ -44,10 +41,10 @@ namespace Gsplat
         // Matches the RendererParams struct in GsplatSparkGlobal.hlsl (16-byte stride).
         struct RendererParams
         {
-            public float brightness;
-            public float scaleFactor;
-            public uint gammaToLinear;
-            public uint shDegree;
+            public float Brightness;
+            public float ScaleFactor;
+            public uint GammaToLinear;
+            public uint SHDegree;
         }
 
         // Scratch buffers for merge passes.
@@ -70,7 +67,6 @@ namespace Gsplat
                              && m_kernelCopyUint2 >= 0;
 
         static readonly ProfilingSampler k_samplerMerge = new("Gsplat.MergeKWay");
-        static readonly ProfilingSampler k_samplerDraw = new("Gsplat.DrawAll");
 
         // -----------------------------------------------------------------------
         // Shader property IDs — merge / pack
@@ -156,28 +152,32 @@ namespace Gsplat
             m_globalBuffersDirty = true;
         }
 
-        public void Dispatch(CommandBuffer cmd, List<IGsplat> activeGsplats)
+        public void Update(List<IGsplat> activeGsplats)
         {
-            cmd.BeginSample(k_samplerMerge.name);
-            EnsureGlobalBuffers(cmd, activeGsplats);
-            // If EnsureGlobalBuffers failed (uncompressed asset, >255 renderers, etc.),
-            // m_globalOrderBuffer is null.
-            if (m_globalOrderBuffer == null)
-            {
-                cmd.EndSample(k_samplerMerge.name);
-                return;
-            }
-
+            EnsureGlobalBuffers(activeGsplats);
+            if (m_totalSplatCount == 0) return;
             UpdateRendererTransforms(activeGsplats);
             UpdateRendererParams(activeGsplats);
-            DispatchMerge(cmd, activeGsplats);
+            Render();
+        }
+
+        public void DispatchMerge(CommandBuffer cmd, List<IGsplat> activeGsplats)
+        {
+            if (m_totalSplatCount == 0) return;
+            cmd.BeginSample(k_samplerMerge.name);
+            DispatchMergeInternal(cmd, activeGsplats);
             cmd.EndSample(k_samplerMerge.name);
         }
+
+        /// <summary>
+        /// Call when a renderer's asset changes so the global packed buffer is rebuilt next frame.
+        /// </summary>
+        public void MarkGlobalBuffersDirty() => m_globalBuffersDirty = true;
 
         // -----------------------------------------------------------------------
         // Global buffer management
         // -----------------------------------------------------------------------
-        void EnsureGlobalBuffers(CommandBuffer cmd, List<IGsplat> activeGsplats)
+        void EnsureGlobalBuffers(List<IGsplat> activeGsplats)
         {
             // A renderer streaming in its splats via async upload (AsyncUpload +
             // RenderBeforeUploadComplete) grows its SplatCount frame to frame. Rebuild when an
@@ -200,13 +200,12 @@ namespace Gsplat
             // clamped to its own asset bands in UpdateRendererParams.
             m_globalSHBands = 0;
 
-            foreach (var gs in activeGsplats)
-                if (gs.SHBands > m_globalSHBands)
-                    m_globalSHBands = gs.SHBands;
+            foreach (var gs in activeGsplats.Where(gs => gs.SHBands > m_globalSHBands))
+                m_globalSHBands = gs.SHBands;
 
             for (int k = 0; k < activeGsplats.Count; k++)
             {
-                uint count = activeGsplats[k].SplatCount;
+                var count = activeGsplats[k].SplatCount;
                 m_rendererOffsets[k] = m_totalSplatCount;
                 m_builtSplatCounts[k] = count;
                 m_totalSplatCount += count;
@@ -254,15 +253,15 @@ namespace Gsplat
 
                 var res = (GsplatResourceSpark)gs.GsplatResource;
 
-                CopyUint4(cmd, res.PackedSplatsBuffer, m_globalPackedBuffer, count, off);
+                CopyUint4(res.PackedSplatsBuffer, m_globalPackedBuffer, count, off);
                 if (m_globalSHBands >= 1 && res.PackedSH1Buffer != null)
-                    CopyUint2(cmd, res.PackedSH1Buffer, m_globalSH1Buffer, count, off);
+                    CopyUint2(res.PackedSH1Buffer, m_globalSH1Buffer, count, off);
                 if (m_globalSHBands >= 2 && res.PackedSH2Buffer != null)
-                    CopyUint4(cmd, res.PackedSH2Buffer, m_globalSH2Buffer, count, off);
+                    CopyUint4(res.PackedSH2Buffer, m_globalSH2Buffer, count, off);
                 if (m_globalSHBands >= 3 && res.PackedSH3Buffer != null)
-                    CopyUint4(cmd, res.PackedSH3Buffer, m_globalSH3Buffer, count, off);
+                    CopyUint4(res.PackedSH3Buffer, m_globalSH3Buffer, count, off);
                 if (m_globalSHBands >= 4 && res.PackedSH4Buffer != null)
-                    CopyUint4(cmd, res.PackedSH4Buffer, m_globalSH4Buffer, count, off);
+                    CopyUint4(res.PackedSH4Buffer, m_globalSH4Buffer, count, off);
             }
 
             // Allocate merge scratch buffers (always fresh after a dirty rebuild).
@@ -289,7 +288,7 @@ namespace Gsplat
         void UpdateRendererTransforms(List<IGsplat> activeGsplats)
         {
             if (m_rendererTransformsBuffer == null) return;
-            int count = activeGsplats.Count;
+            var count = activeGsplats.Count;
             if (m_rendererTransformsCache == null || m_rendererTransformsCache.Length != count)
                 m_rendererTransformsCache = new Matrix4x4[count];
             for (int k = 0; k < count; k++)
@@ -300,7 +299,7 @@ namespace Gsplat
         void UpdateRendererParams(List<IGsplat> activeGsplats)
         {
             if (m_rendererParamsBuffer == null) return;
-            int count = activeGsplats.Count;
+            var count = activeGsplats.Count;
             if (m_rendererParamsCache == null || m_rendererParamsCache.Length != count)
                 m_rendererParamsCache = new RendererParams[count];
             for (int k = 0; k < count; k++)
@@ -310,23 +309,23 @@ namespace Gsplat
                 {
                     m_rendererParamsCache[k] = new RendererParams
                     {
-                        brightness = gs.Brightness,
-                        scaleFactor = 1.0f - gs.SplatDownscaleFactor,
-                        gammaToLinear = gs.GammaToLinear ? 1u : 0u,
+                        Brightness = gs.Brightness,
+                        ScaleFactor = 1.0f - gs.SplatDownscaleFactor,
+                        GammaToLinear = gs.GammaToLinear ? 1u : 0u,
                         // Clamp to the asset's own bands so EvalSH never reads slots that
                         // weren't copied for this renderer (the global buffers are sized to
                         // the max bands across the set).
-                        shDegree = (uint)Mathf.Min(gs.SHDegree, activeGsplats[k].SHBands),
+                        SHDegree = (uint)Mathf.Min(gs.SHDegree, activeGsplats[k].SHBands),
                     };
                 }
                 else
                 {
                     m_rendererParamsCache[k] = new RendererParams
                     {
-                        brightness = 1.0f,
-                        scaleFactor = 1.0f,
-                        gammaToLinear = 0u,
-                        shDegree = activeGsplats[k].SHBands,
+                        Brightness = 1.0f,
+                        ScaleFactor = 1.0f,
+                        GammaToLinear = 0u,
+                        SHDegree = activeGsplats[k].SHBands,
                     };
                 }
             }
@@ -335,32 +334,32 @@ namespace Gsplat
         }
 
         // -----------------------------------------------------------------------
-        // Copy helpers (GPU-side via command buffer)
+        // Copy helpers
         // -----------------------------------------------------------------------
-        void CopyUint4(CommandBuffer cmd, GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
+        void CopyUint4(GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
         {
-            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_srcElementCount, (int)count);
-            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_dstElementOffset, (int)dstOff);
-            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, k_srcUint4, src);
-            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, k_dstUint4, dst);
-            cmd.DispatchCompute(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4,
-                (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
+            var cs = m_globalMaterial.CopyBufferShader;
+            cs.SetInt(k_srcElementCount, (int)count);
+            cs.SetInt(k_dstElementOffset, (int)dstOff);
+            cs.SetBuffer(m_kernelCopyUint4, k_srcUint4, src);
+            cs.SetBuffer(m_kernelCopyUint4, k_dstUint4, dst);
+            cs.Dispatch(m_kernelCopyUint4, (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
         }
 
-        void CopyUint2(CommandBuffer cmd, GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
+        void CopyUint2(GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
         {
-            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_srcElementCount, (int)count);
-            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_dstElementOffset, (int)dstOff);
-            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, k_srcUint2, src);
-            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, k_dstUint2, dst);
-            cmd.DispatchCompute(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2,
-                (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
+            var cs = m_globalMaterial.CopyBufferShader;
+            cs.SetInt(k_srcElementCount, (int)count);
+            cs.SetInt(k_dstElementOffset, (int)dstOff);
+            cs.SetBuffer(m_kernelCopyUint2, k_srcUint2, src);
+            cs.SetBuffer(m_kernelCopyUint2, k_dstUint2, dst);
+            cs.Dispatch(m_kernelCopyUint2, (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
         }
 
         // -----------------------------------------------------------------------
         // Merge dispatch
         // -----------------------------------------------------------------------
-        void DispatchMerge(CommandBuffer cmd, List<IGsplat> activeGsplats)
+        void DispatchMergeInternal(CommandBuffer cmd, List<IGsplat> activeGsplats)
         {
             int K = activeGsplats.Count;
             if (K < 2 || m_globalOrderBuffer == null) return;
@@ -460,18 +459,12 @@ namespace Gsplat
         // -----------------------------------------------------------------------
         // Global draw call
         // -----------------------------------------------------------------------
-
-
-        public void DrawAll(CommandBuffer cmd, Camera camera)
+        void Render()
         {
             // m_globalBuffersDirty: the active renderer set changed and the next DispatchSort
             // hasn't validated/rebuilt the buffers yet. Drawing now would bind stale buffers
             // (under URP, DrawAllIfEnabled fires before DispatchSort each frame).
             if (m_globalBuffersDirty || m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
-
-            cmd?.BeginSample(k_samplerDraw.name);
-
-            var mat = m_globalMaterial.Materials[m_globalSHBands];
 
             // Bind buffers via a MaterialPropertyBlock rather than on the material itself, so
             // each queued draw captures its own bindings and multiple cameras (Game + SceneView,
@@ -487,26 +480,23 @@ namespace Gsplat
             m_globalPropertyBlock.SetInteger(k_totalSplatCount, (int)m_totalRemainingCount);
             m_globalPropertyBlock.SetInteger(k_splatInstanceSize, (int)GsplatSettings.Instance.SplatInstanceSize);
 
-            if (m_globalSH1Buffer != null)
+            if (m_globalSHBands >= 1)
                 m_globalPropertyBlock.SetBuffer(k_globalSH1Buffer, m_globalSH1Buffer);
-            if (m_globalSH2Buffer != null)
+            if (m_globalSHBands >= 2)
                 m_globalPropertyBlock.SetBuffer(k_globalSH2Buffer, m_globalSH2Buffer);
-            if (m_globalSH3Buffer != null)
+            if (m_globalSHBands >= 3)
                 m_globalPropertyBlock.SetBuffer(k_globalSH3Buffer, m_globalSH3Buffer);
-            if (m_globalSH4Buffer != null)
+            if (m_globalSHBands >= 4)
                 m_globalPropertyBlock.SetBuffer(k_globalSH4Buffer, m_globalSH4Buffer);
 
-            var rp = new RenderParams(mat)
+            var rp = new RenderParams(m_globalMaterial.Materials[m_globalSHBands])
             {
                 worldBounds = new Bounds(Vector3.zero, Vector3.one * 1e6f),
-                camera = camera,
                 matProps = m_globalPropertyBlock
             };
 
             int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
             Graphics.RenderMeshPrimitives(rp, GsplatSettings.Instance.Mesh, 0, instances);
-
-            cmd?.EndSample(k_samplerDraw.name);
         }
 
 
@@ -546,10 +536,5 @@ namespace Gsplat
             // Drop the build snapshot so the next EnsureGlobalBuffers re-captures counts from scratch.
             m_builtSplatCounts = null;
         }
-
-        /// <summary>
-        /// Call when a renderer's asset changes so the global packed buffer is rebuilt next frame.
-        /// </summary>
-        public void MarkGlobalBuffersDirty() => m_globalBuffersDirty = true;
     }
 }

--- a/Runtime/GsplatGlobalRenderer.cs.meta
+++ b/Runtime/GsplatGlobalRenderer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 61a03526fcd54023b1055cf216f18e03
+timeCreated: 1780753361

--- a/Runtime/GsplatPlayerLoopHook.cs
+++ b/Runtime/GsplatPlayerLoopHook.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) 2026 Yize Wu
+// SPDX-License-Identifier: MIT
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.LowLevel;
+using UnityEngine.PlayerLoop;
+
+
+namespace Gsplat
+{
+    [InitializeOnLoad]
+    public static class GsplatPlayerLoopHook
+    {
+        static bool s_installed;
+
+        static GsplatPlayerLoopHook()
+        {
+            Install();
+            EditorApplication.playModeStateChanged += _ => { Install(); };
+        }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void RuntimeInit()
+        {
+            Install();
+        }
+
+        static void Install()
+        {
+            if (s_installed)
+                return;
+
+            var loop = PlayerLoop.GetCurrentPlayerLoop();
+            InsertBefore<PostLateUpdate>(ref loop, typeof(GsplatPlayerLoopHook), Update);
+            PlayerLoop.SetPlayerLoop(loop);
+            s_installed = true;
+        }
+
+        static bool InsertBefore<T>(ref PlayerLoopSystem root, System.Type type, PlayerLoopSystem.UpdateFunction fn)
+        {
+            if (root.subSystemList == null)
+                return false;
+
+            for (var i = 0; i < root.subSystemList.Length; i++)
+            {
+                ref var sys = ref root.subSystemList[i];
+                if (sys.type == typeof(T))
+                {
+                    var list = sys.subSystemList?.ToList() ?? new List<PlayerLoopSystem>();
+                    list.Insert(0, new PlayerLoopSystem { type = type, updateDelegate = fn });
+                    sys.subSystemList = list.ToArray();
+                    return true;
+                }
+
+                if (InsertBefore<T>(ref sys, type, fn))
+                    return true;
+            }
+
+            return false;
+        }
+        
+        static void Update()
+        {
+            GsplatSorter.Instance.Update();
+        }
+    }
+}

--- a/Runtime/GsplatPlayerLoopHook.cs.meta
+++ b/Runtime/GsplatPlayerLoopHook.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e170e1dac3c648dfa814925e368bc085
+timeCreated: 1780760251

--- a/Runtime/GsplatRenderer.cs
+++ b/Runtime/GsplatRenderer.cs
@@ -19,6 +19,7 @@ namespace Gsplat
         }
 
         public GsplatAsset GsplatAsset;
+
         // Range is enforced by GsplatRendererEditor based on the bound asset's SHBands.
         public int SHDegree = 3;
         [HideInInspector] public uint RenderOrder = 0;
@@ -47,19 +48,10 @@ namespace Gsplat
         public ISorterResource SorterResource => m_renderer.SorterResource;
 
         // IGsplat global-merge members: expose per-renderer GPU buffers for the global sorter.
-        public GraphicsBuffer PackedSplatsBuffer =>
-            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSplatsBuffer;
-        public GraphicsBuffer SH1Buffer =>
-            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSH1Buffer;
-        public GraphicsBuffer SH2Buffer =>
-            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSH2Buffer;
-        public GraphicsBuffer SH3Buffer =>
-            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSH3Buffer;
-        public GraphicsBuffer SH4Buffer =>
-            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSH4Buffer;
+        public GsplatResource GsplatResource => m_renderer?.GsplatResource;
         public byte SHBands => GsplatAsset?.SHBands ?? 0;
 
-        
+
         public uint RemainingCount
         {
             get => m_renderer.m_remainingCount;
@@ -133,7 +125,7 @@ namespace Gsplat
             ForceRefresh();
 #if UNITY_EDITOR
             if (GsplatAsset &&
-                AssetDatabase.TryGetGUIDAndLocalFileIdentifier(GsplatAsset, out var guid, out var localId))
+                AssetDatabase.TryGetGUIDAndLocalFileIdentifier(GsplatAsset, out var guid, out long localId))
                 m_assetGuid = guid;
 #endif // #if UNITY_EDITOR
         }

--- a/Runtime/GsplatRenderer.cs
+++ b/Runtime/GsplatRenderer.cs
@@ -46,6 +46,20 @@ namespace Gsplat
 
         public ISorterResource SorterResource => m_renderer.SorterResource;
 
+        // IGsplat global-merge members: expose per-renderer GPU buffers for the global sorter.
+        public GraphicsBuffer PackedSplatsBuffer =>
+            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSplatsBuffer;
+        public GraphicsBuffer SH1Buffer =>
+            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSH1Buffer;
+        public GraphicsBuffer SH2Buffer =>
+            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSH2Buffer;
+        public GraphicsBuffer SH3Buffer =>
+            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSH3Buffer;
+        public GraphicsBuffer SH4Buffer =>
+            (m_renderer?.GsplatResource as GsplatResourceSpark)?.PackedSH4Buffer;
+        public byte SHBands => GsplatAsset?.SHBands ?? 0;
+
+        
         public uint RemainingCount
         {
             get => m_renderer.m_remainingCount;
@@ -119,7 +133,7 @@ namespace Gsplat
             ForceRefresh();
 #if UNITY_EDITOR
             if (GsplatAsset &&
-                AssetDatabase.TryGetGUIDAndLocalFileIdentifier(GsplatAsset, out var guid, out long localId))
+                AssetDatabase.TryGetGUIDAndLocalFileIdentifier(GsplatAsset, out var guid, out var localId))
                 m_assetGuid = guid;
 #endif // #if UNITY_EDITOR
         }
@@ -149,6 +163,7 @@ namespace Gsplat
                     var asyncUpload = AsyncUpload;
 #endif
                     m_renderer.BindGsplatAsset(GsplatAsset, asyncUpload);
+                    GsplatSorter.Instance.MarkGlobalBuffersDirty();
                 }
             }
 
@@ -156,8 +171,11 @@ namespace Gsplat
             {
                 m_renderer.EvaluateRefreshRequired(SortMode, SortRefreshRate - 1, CutoutsRefreshRate - 1);
                 m_renderer.DispatchInitOrder(Cutouts, transform.localToWorldMatrix, CutoutsUpdateBounds);
-                m_renderer.Render(transform, gameObject.layer, GammaToLinear, SHDegree, Brightness,
-                    1.0f - SplatDownscaleFactor, RenderOrder);
+                // When the global sorter has merged all renderers into a single draw call,
+                // skip the per-renderer draw — GsplatSorter.DrawAll handles rendering.
+                if (!GsplatSorter.Instance.GlobalRenderEnabled)
+                    m_renderer.Render(transform, gameObject.layer, GammaToLinear, SHDegree, Brightness,
+                        1.0f - SplatDownscaleFactor, RenderOrder);
             }
         }
     }

--- a/Runtime/GsplatRendererImpl.cs
+++ b/Runtime/GsplatRendererImpl.cs
@@ -94,7 +94,8 @@ namespace Gsplat
         {
             if (cutouts.Length == 0)
             {
-                SorterResource.Initialized = false;
+                if (m_cutoutsData.Length > 0)
+                    SorterResource.Initialized = false;
                 m_cutoutsData = Array.Empty<GsplatCutout.ShaderData>();
                 m_remainingCount = GsplatResource.UploadedCount;
                 m_bounds = m_gsplatAsset.Bounds;

--- a/Runtime/GsplatSettings.cs
+++ b/Runtime/GsplatSettings.cs
@@ -37,10 +37,11 @@ namespace Gsplat
                     AssetDatabase.CreateAsset(settings, k_gsplatSettingsPath);
                     AssetDatabase.SaveAssets();
                 }
-                else if (settings.Version < new Version("1.2.0"))
+                else if (settings.Version < new Version("1.3.0"))
                 {
                     Debug.Log($"Updated GsplatSettings from version {settings.Version}.");
                     settings.Materials = DefaultMaterials;
+                    settings.GlobalMaterial = DefaultGlobalMaterial;
                     settings.m_prevComputeShader = null;
                     settings.Version = GsplatUtils.k_Version;
                     settings.OnValidate();
@@ -55,6 +56,9 @@ namespace Gsplat
         }
 
         public ComputeShader ComputeShader;
+        public GsplatGlobalMaterial GlobalMaterial;
+        [Tooltip("When enabled, 2+ active Gaussian splat renderers are merged into a single globally depth-sorted draw call.")]
+        public bool EnableGlobalSort = true;
         public uint SplatInstanceSize = 128;
         public uint UploadBatchSize = 100000;
         [Range(1, 20)] public uint MaxRenderOrder = 1;
@@ -82,8 +86,10 @@ namespace Gsplat
 
 #if UNITY_EDITOR
         static ComputeShader DefaultComputeShader => AssetDatabase.LoadAssetAtPath<ComputeShader>(
-            GsplatUtils.k_PackagePath +
-            "Runtime/Shaders/Gsplat.compute");
+            GsplatUtils.k_PackagePath + "Runtime/Shaders/Gsplat.compute");
+
+        static GsplatGlobalMaterial DefaultGlobalMaterial => AssetDatabase.LoadAssetAtPath<GsplatGlobalMaterial>(
+            GsplatUtils.k_PackagePath + "Runtime/Materials/GsplatGlobal.asset");
 
         static GsplatMaterial[] DefaultMaterials
         {
@@ -104,6 +110,7 @@ namespace Gsplat
         {
             Version = GsplatUtils.k_Version;
             ComputeShader = DefaultComputeShader;
+            GlobalMaterial = DefaultGlobalMaterial;
             Materials = DefaultMaterials;
             m_prevComputeShader = null;
             m_prevSplatInstanceSize = 0;
@@ -146,6 +153,8 @@ namespace Gsplat
                 m_prevComputeShader = ComputeShader;
             }
 
+            GsplatSorter.Instance.InitGlobal(GlobalMaterial);
+
             if (SplatInstanceSize != m_prevSplatInstanceSize)
             {
                 DestroyImmediate(Mesh);
@@ -163,6 +172,7 @@ namespace Gsplat
         void OnEnable()
         {
             GsplatSorter.Instance.InitSorter(ComputeShader);
+            GsplatSorter.Instance.InitGlobal(GlobalMaterial);
             m_prevComputeShader = ComputeShader;
 
             CreateMeshInstance();

--- a/Runtime/GsplatSettings.cs
+++ b/Runtime/GsplatSettings.cs
@@ -37,16 +37,28 @@ namespace Gsplat
                     AssetDatabase.CreateAsset(settings, k_gsplatSettingsPath);
                     AssetDatabase.SaveAssets();
                 }
-                else if (settings.Version < new Version("1.3.0"))
+                else
                 {
-                    Debug.Log($"Updated GsplatSettings from version {settings.Version}.");
-                    settings.Materials = DefaultMaterials;
-                    settings.GlobalMaterial = DefaultGlobalMaterial;
-                    settings.m_prevComputeShader = null;
-                    settings.Version = GsplatUtils.k_Version;
-                    settings.OnValidate();
-                    EditorUtility.SetDirty(settings);
-                    AssetDatabase.SaveAssets();
+                    if (settings.Version < new Version("1.2.0"))
+                    {
+                        Debug.Log($"Updated GsplatSettings from version {settings.Version}.");
+                        settings.Materials = DefaultMaterials;
+                        settings.GlobalMaterial = DefaultGlobalMaterial;
+                        settings.m_prevComputeShader = null;
+                        settings.Version = GsplatUtils.k_Version;
+                        settings.OnValidate();
+                        EditorUtility.SetDirty(settings);
+                        AssetDatabase.SaveAssets();
+                    }
+                    else if (settings.Version < new Version("1.4.0"))
+                    {
+                        Debug.Log($"Updated GsplatSettings from version {settings.Version}.");
+                        settings.GlobalMaterial = DefaultGlobalMaterial;
+                        settings.Version = GsplatUtils.k_Version;
+                        settings.OnValidate();
+                        EditorUtility.SetDirty(settings);
+                        AssetDatabase.SaveAssets();
+                    }
                 }
 #endif
 
@@ -57,16 +69,26 @@ namespace Gsplat
 
         public ComputeShader ComputeShader;
         public GsplatGlobalMaterial GlobalMaterial;
-        [Tooltip("When enabled, 2+ active Gaussian splat renderers are merged into a single globally depth-sorted draw call.")]
+
+        [Tooltip(
+            "When enabled, 2+ active Gaussian splat renderers are merged into a single globally depth-sorted draw call.")]
         public bool EnableGlobalSort;
+
         public uint SplatInstanceSize;
         public uint UploadBatchSize;
         [Range(1, 20)] public uint MaxRenderOrder;
         public bool DisplayBoundingBoxes;
-        [Tooltip("If a camera moves more that this threshold, each GsplatRenderer compute sorting and cutouts regardless of refresh rate")]
-        [Range(0.05f, 1f)] public float CameraTranslationRefreshTreshold;
-        [Tooltip("If a camera rotates more that this threshold, each GsplatRenderer compute sorting and cutouts refresh regardless of refresh rate")]
-        [Range(0.2f, 30f)] public float CameraRotationRefreshTreshold;
+
+        [Tooltip(
+            "If a camera moves more that this threshold, each GsplatRenderer compute sorting and cutouts regardless of refresh rate")]
+        [Range(0.05f, 1f)]
+        public float CameraTranslationRefreshTreshold;
+
+        [Tooltip(
+            "If a camera rotates more that this threshold, each GsplatRenderer compute sorting and cutouts refresh regardless of refresh rate")]
+        [Range(0.2f, 30f)]
+        public float CameraRotationRefreshTreshold;
+
         public bool ShowImportErrors;
         public GsplatMaterial[] Materials;
         public Mesh Mesh { get; private set; }
@@ -174,6 +196,7 @@ namespace Gsplat
             {
                 mat.Reset();
             }
+
             if (GlobalMaterial)
                 GlobalMaterial.Reset();
 #endif

--- a/Runtime/GsplatSettings.cs
+++ b/Runtime/GsplatSettings.cs
@@ -58,7 +58,7 @@ namespace Gsplat
         public ComputeShader ComputeShader;
         public GsplatGlobalMaterial GlobalMaterial;
         [Tooltip("When enabled, 2+ active Gaussian splat renderers are merged into a single globally depth-sorted draw call.")]
-        public bool EnableGlobalSort = true;
+        public bool EnableGlobalSort = false;
         public uint SplatInstanceSize = 128;
         public uint UploadBatchSize = 100000;
         [Range(1, 20)] public uint MaxRenderOrder = 1;
@@ -166,6 +166,8 @@ namespace Gsplat
             {
                 mat.Reset();
             }
+            if (GlobalMaterial)
+                GlobalMaterial.Reset();
 #endif
         }
 

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -116,6 +116,7 @@ namespace Gsplat
         GraphicsBuffer m_mergeScratchDepths;
         uint           m_scratchCapacity;
         Matrix4x4[]    m_rendererTransformsCache;
+        MaterialPropertyBlock m_globalPropertyBlock;
 
         /// <summary>True when 2+ active renderers are being globally merged this frame.</summary>
         public bool GlobalRenderEnabled { get; private set; }
@@ -623,36 +624,44 @@ namespace Gsplat
             cmd?.BeginSample(k_samplerDraw.name);
 
             var mat = m_globalMaterial.Materials[m_globalSHBands];
-            mat.SetBuffer(k_globalOrderBuffer,      m_globalOrderBuffer);
-            mat.SetBuffer(k_globalPackedBuffer,     m_globalPackedBuffer);
-            mat.SetBuffer(k_rendererOffsetsProp,    m_rendererOffsetsBuffer);
-            mat.SetBuffer(k_rendererTransformsProp, m_rendererTransformsBuffer);
-            mat.SetInt(k_totalSplatCount,           (int)m_totalRemainingCount);
-            mat.SetInt(k_splatInstanceSize,         (int)GsplatSettings.Instance.SplatInstanceSize);
+
+            // Bind buffers via a MaterialPropertyBlock rather than on the material itself, so
+            // each queued draw captures its own bindings and multiple cameras (Game + SceneView,
+            // or any multi-camera setup) don't overwrite one another's state before the GPU
+            // executes them.
+            m_globalPropertyBlock ??= new MaterialPropertyBlock();
+            m_globalPropertyBlock.Clear();
+            m_globalPropertyBlock.SetBuffer(k_globalOrderBuffer,      m_globalOrderBuffer);
+            m_globalPropertyBlock.SetBuffer(k_globalPackedBuffer,     m_globalPackedBuffer);
+            m_globalPropertyBlock.SetBuffer(k_rendererOffsetsProp,    m_rendererOffsetsBuffer);
+            m_globalPropertyBlock.SetBuffer(k_rendererTransformsProp, m_rendererTransformsBuffer);
+            m_globalPropertyBlock.SetInteger(k_totalSplatCount,       (int)m_totalRemainingCount);
+            m_globalPropertyBlock.SetInteger(k_splatInstanceSize,     (int)GsplatSettings.Instance.SplatInstanceSize);
 
             if (m_globalSH1Buffer != null)
-                mat.SetBuffer(k_globalSH1Buffer, m_globalSH1Buffer);
+                m_globalPropertyBlock.SetBuffer(k_globalSH1Buffer, m_globalSH1Buffer);
             if (m_globalSH2Buffer != null)
-                mat.SetBuffer(k_globalSH2Buffer, m_globalSH2Buffer);
+                m_globalPropertyBlock.SetBuffer(k_globalSH2Buffer, m_globalSH2Buffer);
             if (m_globalSH3Buffer != null)
-                mat.SetBuffer(k_globalSH3Buffer, m_globalSH3Buffer);
+                m_globalPropertyBlock.SetBuffer(k_globalSH3Buffer, m_globalSH3Buffer);
             if (m_globalSH4Buffer != null)
-                mat.SetBuffer(k_globalSH4Buffer, m_globalSH4Buffer);
+                m_globalPropertyBlock.SetBuffer(k_globalSH4Buffer, m_globalSH4Buffer);
 
             // Use the first renderer's visual settings as representative.
             var rep = m_activeGsplats[0] as GsplatRenderer;
             if (rep != null)
             {
-                mat.SetFloat(k_brightness,  rep.Brightness);
-                mat.SetFloat(k_scaleFactor, 1.0f - rep.SplatDownscaleFactor);
-                mat.SetInt(k_gammaToLinear, rep.GammaToLinear ? 1 : 0);
-                mat.SetInt(k_shDegree,      Mathf.Min(rep.SHDegree, m_globalSHBands));
+                m_globalPropertyBlock.SetFloat(k_brightness,    rep.Brightness);
+                m_globalPropertyBlock.SetFloat(k_scaleFactor,   1.0f - rep.SplatDownscaleFactor);
+                m_globalPropertyBlock.SetInteger(k_gammaToLinear, rep.GammaToLinear ? 1 : 0);
+                m_globalPropertyBlock.SetInteger(k_shDegree,      Mathf.Min(rep.SHDegree, m_globalSHBands));
             }
 
             var rp = new RenderParams(mat)
             {
                 worldBounds = new Bounds(Vector3.zero, Vector3.one * 1e6f),
-                camera      = camera
+                camera      = camera,
+                matProps    = m_globalPropertyBlock
             };
 
             int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -106,6 +106,17 @@ namespace Gsplat
         GraphicsBuffer m_globalOrderBuffer;
         GraphicsBuffer m_rendererOffsetsBuffer;
         GraphicsBuffer m_rendererTransformsBuffer;
+        GraphicsBuffer m_rendererParamsBuffer;
+
+        // Per-renderer visual settings, looked up by renderer_id during the merged draw.
+        // Matches the RendererParams struct in GsplatSparkGlobal.hlsl (16-byte stride).
+        struct RendererParams
+        {
+            public float brightness;
+            public float scaleFactor;
+            public uint  gammaToLinear;
+            public uint  shDegree;
+        }
 
         // Scratch buffers for merge passes.
         // m_packScratch*  : all renderers' orders+depths packed and concatenated.
@@ -115,7 +126,8 @@ namespace Gsplat
         GraphicsBuffer m_mergeScratchOrders;
         GraphicsBuffer m_mergeScratchDepths;
         uint           m_scratchCapacity;
-        Matrix4x4[]    m_rendererTransformsCache;
+        Matrix4x4[]      m_rendererTransformsCache;
+        RendererParams[] m_rendererParamsCache;
         MaterialPropertyBlock m_globalPropertyBlock;
 
         /// <summary>True when 2+ active renderers are being globally merged this frame.</summary>
@@ -167,14 +179,11 @@ namespace Gsplat
         static readonly int k_globalSH2Buffer        = Shader.PropertyToID("_GlobalSH2Buffer");
         static readonly int k_globalSH3Buffer        = Shader.PropertyToID("_GlobalSH3Buffer");
         static readonly int k_globalSH4Buffer        = Shader.PropertyToID("_GlobalSH4Buffer");
-        static readonly int k_shDegree               = Shader.PropertyToID("_SHDegree");
         static readonly int k_rendererOffsetsProp    = Shader.PropertyToID("_RendererOffsets");
         static readonly int k_rendererTransformsProp = Shader.PropertyToID("_RendererTransforms");
+        static readonly int k_rendererParamsProp     = Shader.PropertyToID("_RendererParams");
         static readonly int k_totalSplatCount        = Shader.PropertyToID("_TotalSplatCount");
         static readonly int k_splatInstanceSize      = Shader.PropertyToID("_SplatInstanceSize");
-        static readonly int k_brightness             = Shader.PropertyToID("_Brightness");
-        static readonly int k_scaleFactor            = Shader.PropertyToID("_ScaleFactor");
-        static readonly int k_gammaToLinear          = Shader.PropertyToID("_GammaToLinear");
 
         // -----------------------------------------------------------------------
         // Validity
@@ -402,6 +411,7 @@ namespace Gsplat
                 return;
             }
             UpdateRendererTransforms();
+            UpdateRendererParams();
             DispatchMerge(cmd);
             cmd.EndSample(k_samplerMerge.name);
         }
@@ -418,10 +428,13 @@ namespace Gsplat
 
             m_totalSplatCount = 0;
             m_rendererOffsets = new uint[m_activeGsplats.Count];
-            m_globalSHBands   = m_activeGsplats.Count > 0 ? m_activeGsplats[0].SHBands : (byte)0;
+            // Size SH buffers to the highest band count in the set; lower-band renderers
+            // occupy the extra slots but never read them, since each renderer's SHDegree is
+            // clamped to its own asset bands in UpdateRendererParams.
+            m_globalSHBands   = 0;
 
             foreach (var gs in m_activeGsplats)
-                if (gs.SHBands < m_globalSHBands) m_globalSHBands = gs.SHBands;
+                if (gs.SHBands > m_globalSHBands) m_globalSHBands = gs.SHBands;
 
             for (int k = 0; k < m_activeGsplats.Count; k++)
             {
@@ -439,6 +452,7 @@ namespace Gsplat
             m_globalOrderBuffer        = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))     { name = "Gsplat.GlobalOrder" };
             m_rendererOffsetsBuffer    = new GraphicsBuffer(st, m_activeGsplats.Count,  sizeof(uint))     { name = "Gsplat.RendererOffsets" };
             m_rendererTransformsBuffer = new GraphicsBuffer(st, m_activeGsplats.Count,  sizeof(float)*16) { name = "Gsplat.RendererTransforms" };
+            m_rendererParamsBuffer     = new GraphicsBuffer(st, m_activeGsplats.Count,  sizeof(float)*2 + sizeof(uint)*2) { name = "Gsplat.RendererParams" };
 
             if (m_globalSHBands >= 1)
                 m_globalSH1Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 2) { name = "Gsplat.GlobalSH1" };
@@ -487,6 +501,42 @@ namespace Gsplat
             for (int k = 0; k < count; k++)
                 m_rendererTransformsCache[k] = m_activeGsplats[k].transform.localToWorldMatrix;
             m_rendererTransformsBuffer.SetData(m_rendererTransformsCache);
+        }
+
+        void UpdateRendererParams()
+        {
+            if (m_rendererParamsBuffer == null) return;
+            int count = m_activeGsplats.Count;
+            if (m_rendererParamsCache == null || m_rendererParamsCache.Length != count)
+                m_rendererParamsCache = new RendererParams[count];
+            for (int k = 0; k < count; k++)
+            {
+                var gs = m_activeGsplats[k] as GsplatRenderer;
+                if (gs != null)
+                {
+                    m_rendererParamsCache[k] = new RendererParams
+                    {
+                        brightness    = gs.Brightness,
+                        scaleFactor   = 1.0f - gs.SplatDownscaleFactor,
+                        gammaToLinear = gs.GammaToLinear ? 1u : 0u,
+                        // Clamp to the asset's own bands so EvalSH never reads slots that
+                        // weren't copied for this renderer (the global buffers are sized to
+                        // the max bands across the set).
+                        shDegree      = (uint)Mathf.Min(gs.SHDegree, m_activeGsplats[k].SHBands),
+                    };
+                }
+                else
+                {
+                    m_rendererParamsCache[k] = new RendererParams
+                    {
+                        brightness    = 1.0f,
+                        scaleFactor   = 1.0f,
+                        gammaToLinear = 0u,
+                        shDegree      = m_activeGsplats[k].SHBands,
+                    };
+                }
+            }
+            m_rendererParamsBuffer.SetData(m_rendererParamsCache);
         }
 
         // -----------------------------------------------------------------------
@@ -635,6 +685,7 @@ namespace Gsplat
             m_globalPropertyBlock.SetBuffer(k_globalPackedBuffer,     m_globalPackedBuffer);
             m_globalPropertyBlock.SetBuffer(k_rendererOffsetsProp,    m_rendererOffsetsBuffer);
             m_globalPropertyBlock.SetBuffer(k_rendererTransformsProp, m_rendererTransformsBuffer);
+            m_globalPropertyBlock.SetBuffer(k_rendererParamsProp,     m_rendererParamsBuffer);
             m_globalPropertyBlock.SetInteger(k_totalSplatCount,       (int)m_totalRemainingCount);
             m_globalPropertyBlock.SetInteger(k_splatInstanceSize,     (int)GsplatSettings.Instance.SplatInstanceSize);
 
@@ -646,16 +697,6 @@ namespace Gsplat
                 m_globalPropertyBlock.SetBuffer(k_globalSH3Buffer, m_globalSH3Buffer);
             if (m_globalSH4Buffer != null)
                 m_globalPropertyBlock.SetBuffer(k_globalSH4Buffer, m_globalSH4Buffer);
-
-            // Use the first renderer's visual settings as representative.
-            var rep = m_activeGsplats[0] as GsplatRenderer;
-            if (rep != null)
-            {
-                m_globalPropertyBlock.SetFloat(k_brightness,    rep.Brightness);
-                m_globalPropertyBlock.SetFloat(k_scaleFactor,   1.0f - rep.SplatDownscaleFactor);
-                m_globalPropertyBlock.SetInteger(k_gammaToLinear, rep.GammaToLinear ? 1 : 0);
-                m_globalPropertyBlock.SetInteger(k_shDegree,      Mathf.Min(rep.SHDegree, m_globalSHBands));
-            }
 
             var rp = new RenderParams(mat)
             {
@@ -683,6 +724,7 @@ namespace Gsplat
             m_globalOrderBuffer?.Dispose();         m_globalOrderBuffer        = null;
             m_rendererOffsetsBuffer?.Dispose();     m_rendererOffsetsBuffer    = null;
             m_rendererTransformsBuffer?.Dispose();  m_rendererTransformsBuffer = null;
+            m_rendererParamsBuffer?.Dispose();      m_rendererParamsBuffer     = null;
             // Scratch buffers are rebuilt every time global buffers are rebuilt,
             // so dispose them here too to avoid leaking when renderer count shrinks.
             m_packScratchOrders?.Dispose();         m_packScratchOrders        = null;

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -92,6 +92,7 @@ namespace Gsplat
 
         // CPU-side per-renderer metadata (rebuilt when renderers change).
         uint[] m_rendererOffsets;   // splat start index in global buffers, per active renderer
+        uint[] m_builtSplatCounts;  // per-renderer SplatCount captured when the global buffers were last built
         uint   m_totalSplatCount;
         uint   m_totalRemainingCount; // sum of RemainingCounts; valid entries in GlobalOrderBuffer after merge
         byte   m_globalSHBands;
@@ -421,13 +422,22 @@ namespace Gsplat
         // -----------------------------------------------------------------------
         void EnsureGlobalBuffers(CommandBuffer cmd)
         {
+            // A renderer streaming in its splats via async upload (AsyncUpload +
+            // RenderBeforeUploadComplete) grows its SplatCount frame to frame. Rebuild when an
+            // active renderer's count no longer matches what we last built with, otherwise the
+            // global sub-ranges keep only the splats present at the first build and the rest are
+            // never copied in (leaving the merge to read stale/under-sized global buffers).
+            if (!m_globalBuffersDirty && ActiveSplatCountsChanged())
+                m_globalBuffersDirty = true;
+
             if (!m_globalBuffersDirty) return;
             m_globalBuffersDirty = false;
 
             DisposeGlobalBuffers();
 
             m_totalSplatCount = 0;
-            m_rendererOffsets = new uint[m_activeGsplats.Count];
+            m_rendererOffsets  = new uint[m_activeGsplats.Count];
+            m_builtSplatCounts = new uint[m_activeGsplats.Count];
             // Size SH buffers to the highest band count in the set; lower-band renderers
             // occupy the extra slots but never read them, since each renderer's SHDegree is
             // clamped to its own asset bands in UpdateRendererParams.
@@ -438,8 +448,10 @@ namespace Gsplat
 
             for (int k = 0; k < m_activeGsplats.Count; k++)
             {
-                m_rendererOffsets[k] = m_totalSplatCount;
-                m_totalSplatCount   += m_activeGsplats[k].SplatCount;
+                uint count = m_activeGsplats[k].SplatCount;
+                m_rendererOffsets[k]  = m_totalSplatCount;
+                m_builtSplatCounts[k] = count;
+                m_totalSplatCount    += count;
             }
 
             if (m_totalSplatCount == 0) return;
@@ -490,6 +502,19 @@ namespace Gsplat
             m_mergeScratchOrders = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))  { name = "Gsplat.MergeScratchOrders" };
             m_mergeScratchDepths = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(float)) { name = "Gsplat.MergeScratchDepths" };
             m_scratchCapacity    = m_totalSplatCount;
+        }
+
+        // True when an active renderer's SplatCount no longer matches what the global buffers were
+        // built with (e.g. an async upload has streamed in more splats since the last rebuild).
+        // Active-set size changes are already covered by MarkGlobalBuffersDirty on register/unregister.
+        bool ActiveSplatCountsChanged()
+        {
+            if (m_builtSplatCounts == null || m_builtSplatCounts.Length != m_activeGsplats.Count)
+                return true;
+            for (int k = 0; k < m_activeGsplats.Count; k++)
+                if (m_builtSplatCounts[k] != m_activeGsplats[k].SplatCount)
+                    return true;
+            return false;
         }
 
         void UpdateRendererTransforms()
@@ -732,6 +757,8 @@ namespace Gsplat
             m_mergeScratchOrders?.Dispose();        m_mergeScratchOrders       = null;
             m_mergeScratchDepths?.Dispose();        m_mergeScratchDepths       = null;
             m_scratchCapacity = 0;
+            // Drop the build snapshot so the next EnsureGlobalBuffers re-captures counts from scratch.
+            m_builtSplatCounts = null;
         }
 
         // -----------------------------------------------------------------------

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -20,11 +20,7 @@ namespace Gsplat
         public void ComputeDepth(CommandBuffer cmd, Matrix4x4 matrixMv);
 
         // Used by GsplatSorter to populate the global packed buffer.
-        public GraphicsBuffer PackedSplatsBuffer { get; }
-        public GraphicsBuffer SH1Buffer { get; }
-        public GraphicsBuffer SH2Buffer { get; }
-        public GraphicsBuffer SH3Buffer { get; }
-        public GraphicsBuffer SH4Buffer { get; }
+        public GsplatResource GsplatResource { get; }
         public uint SplatCount { get; }
         public byte SHBands { get; }
     }
@@ -65,9 +61,6 @@ namespace Gsplat
             }
         }
 
-        // -----------------------------------------------------------------------
-        // Singleton
-        // -----------------------------------------------------------------------
         public static GsplatSorter Instance => s_instance ??= new GsplatSorter();
         static GsplatSorter s_instance;
 
@@ -79,130 +72,16 @@ namespace Gsplat
         GsplatSortPass m_sortPass;
         public const string k_PassName = "SortGsplats";
 
-        // -----------------------------------------------------------------------
-        // Global merge state
-        // -----------------------------------------------------------------------
-        GsplatGlobalMaterial m_globalMaterial;
-
-        int m_kernelPackOrders        = -1;
-        int m_kernelMergeTwo          = -1;
-        int m_kernelMergeTwoWithDepth = -1;
-        int m_kernelCopyUint4         = -1;
-        int m_kernelCopyUint2         = -1;
-
-        // CPU-side per-renderer metadata (rebuilt when renderers change).
-        uint[] m_rendererOffsets;   // splat start index in global buffers, per active renderer
-        uint[] m_builtSplatCounts;  // per-renderer SplatCount captured when the global buffers were last built
-        uint   m_totalSplatCount;
-        uint   m_totalRemainingCount; // sum of RemainingCounts; valid entries in GlobalOrderBuffer after merge
-        byte   m_globalSHBands;
-        bool   m_globalBuffersDirty = true;
-
-        // Global packed data buffers (sub-ranges owned by each renderer).
-        GraphicsBuffer m_globalPackedBuffer;
-        GraphicsBuffer m_globalSH1Buffer;
-        GraphicsBuffer m_globalSH2Buffer;
-        GraphicsBuffer m_globalSH3Buffer;
-        GraphicsBuffer m_globalSH4Buffer;
-        GraphicsBuffer m_globalOrderBuffer;
-        GraphicsBuffer m_rendererOffsetsBuffer;
-        GraphicsBuffer m_rendererTransformsBuffer;
-        GraphicsBuffer m_rendererParamsBuffer;
-
-        // Per-renderer visual settings, looked up by renderer_id during the merged draw.
-        // Matches the RendererParams struct in GsplatSparkGlobal.hlsl (16-byte stride).
-        struct RendererParams
-        {
-            public float brightness;
-            public float scaleFactor;
-            public uint  gammaToLinear;
-            public uint  shDegree;
-        }
-
-        // Scratch buffers for merge passes.
-        // m_packScratch*  : all renderers' orders+depths packed and concatenated.
-        // m_mergeScratch* : ping-pong pair for cascaded intermediate merges.
-        GraphicsBuffer m_packScratchOrders;
-        GraphicsBuffer m_packScratchDepths;
-        GraphicsBuffer m_mergeScratchOrders;
-        GraphicsBuffer m_mergeScratchDepths;
-        uint           m_scratchCapacity;
-        Matrix4x4[]      m_rendererTransformsCache;
-        RendererParams[] m_rendererParamsCache;
-        MaterialPropertyBlock m_globalPropertyBlock;
+        readonly GsplatGlobalRenderer m_globalRenderer = new();
 
         /// <summary>True when 2+ active renderers are being globally merged this frame.</summary>
         public bool GlobalRenderEnabled { get; private set; }
 
-        // -----------------------------------------------------------------------
-        // Profiling samplers
-        // -----------------------------------------------------------------------
         static readonly ProfilingSampler k_samplerDepth = new("Gsplat.DepthPerRenderer");
-        static readonly ProfilingSampler k_samplerSort  = new("Gsplat.SortPerRenderer");
-        static readonly ProfilingSampler k_samplerMerge = new("Gsplat.MergeKWay");
-        static readonly ProfilingSampler k_samplerDraw  = new("Gsplat.DrawAll");
+        static readonly ProfilingSampler k_samplerSort = new("Gsplat.SortPerRenderer");
 
-        // -----------------------------------------------------------------------
-        // Shader property IDs — merge / pack
-        // -----------------------------------------------------------------------
-        static readonly int k_rawOrders      = Shader.PropertyToID("_RawOrders");
-        static readonly int k_rawDepths      = Shader.PropertyToID("_RawDepths");
-        static readonly int k_packedOrders   = Shader.PropertyToID("_PackedOrders");
-        static readonly int k_packedDepths   = Shader.PropertyToID("_PackedDepths");
-        static readonly int k_rendererIdx    = Shader.PropertyToID("_RendererIdx");
-        static readonly int k_srcCount       = Shader.PropertyToID("_SrcCount");
-        static readonly int k_dstOffset      = Shader.PropertyToID("_DstOffset");
-
-        static readonly int k_depthsA        = Shader.PropertyToID("_DepthsA");
-        static readonly int k_ordersA        = Shader.PropertyToID("_OrdersA");
-        static readonly int k_depthsB        = Shader.PropertyToID("_DepthsB");
-        static readonly int k_ordersB        = Shader.PropertyToID("_OrdersB");
-        static readonly int k_offsetA        = Shader.PropertyToID("_OffsetA");
-        static readonly int k_offsetB        = Shader.PropertyToID("_OffsetB");
-        static readonly int k_countA         = Shader.PropertyToID("_CountA");
-        static readonly int k_countB         = Shader.PropertyToID("_CountB");
-        static readonly int k_outputOffset   = Shader.PropertyToID("_OutputOffset");
-        static readonly int k_outputOrders   = Shader.PropertyToID("_OutputOrders");
-        static readonly int k_outputDepths   = Shader.PropertyToID("_OutputDepths");
-
-        // Copy kernel IDs
-        static readonly int k_srcUint4         = Shader.PropertyToID("_SrcUint4");
-        static readonly int k_dstUint4         = Shader.PropertyToID("_DstUint4");
-        static readonly int k_srcUint2         = Shader.PropertyToID("_SrcUint2");
-        static readonly int k_dstUint2         = Shader.PropertyToID("_DstUint2");
-        static readonly int k_srcElementCount  = Shader.PropertyToID("_SrcElementCount");
-        static readonly int k_dstElementOffset = Shader.PropertyToID("_DstElementOffset");
-
-        // Global draw material properties
-        static readonly int k_globalOrderBuffer      = Shader.PropertyToID("_GlobalOrderBuffer");
-        static readonly int k_globalPackedBuffer     = Shader.PropertyToID("_GlobalPackedBuffer");
-        static readonly int k_globalSH1Buffer        = Shader.PropertyToID("_GlobalSH1Buffer");
-        static readonly int k_globalSH2Buffer        = Shader.PropertyToID("_GlobalSH2Buffer");
-        static readonly int k_globalSH3Buffer        = Shader.PropertyToID("_GlobalSH3Buffer");
-        static readonly int k_globalSH4Buffer        = Shader.PropertyToID("_GlobalSH4Buffer");
-        static readonly int k_rendererOffsetsProp    = Shader.PropertyToID("_RendererOffsets");
-        static readonly int k_rendererTransformsProp = Shader.PropertyToID("_RendererTransforms");
-        static readonly int k_rendererParamsProp     = Shader.PropertyToID("_RendererParams");
-        static readonly int k_totalSplatCount        = Shader.PropertyToID("_TotalSplatCount");
-        static readonly int k_splatInstanceSize      = Shader.PropertyToID("_SplatInstanceSize");
-
-        // -----------------------------------------------------------------------
-        // Validity
-        // -----------------------------------------------------------------------
         public bool Valid => m_sortPass is { Valid: true };
 
-        bool GlobalValid => m_globalMaterial
-                           && m_globalMaterial.MergeShader && m_globalMaterial.CopyBufferShader
-                           && m_globalMaterial.DefaultMaterial
-                           && m_kernelPackOrders >= 0
-                           && m_kernelMergeTwo >= 0
-                           && m_kernelMergeTwoWithDepth >= 0
-                           && m_kernelCopyUint4 >= 0
-                           && m_kernelCopyUint2 >= 0;
-
-        // -----------------------------------------------------------------------
-        // Init
-        // -----------------------------------------------------------------------
         public void InitSorter(ComputeShader computeShader)
         {
             m_sortPass = computeShader ? new GsplatSortPass(computeShader) : null;
@@ -210,44 +89,9 @@ namespace Gsplat
 
         public void InitGlobal(GsplatGlobalMaterial globalMaterial)
         {
-            m_globalMaterial     = globalMaterial;
-            m_kernelPackOrders   = -1;
-            m_kernelMergeTwo     = -1;
-            m_kernelMergeTwoWithDepth = -1;
-            m_kernelCopyUint4    = -1;
-            m_kernelCopyUint2    = -1;
-
-            var mergeShader = globalMaterial ? globalMaterial.MergeShader : null;
-            var copyShader  = globalMaterial ? globalMaterial.CopyBufferShader : null;
-
-            if (mergeShader)
-            {
-                if (!mergeShader.HasKernel("PackRendererOrders"))
-                    Debug.LogError($"[GsplatSorter] MergeShader '{mergeShader.name}' is missing kernel 'PackRendererOrders' — assign GsplatMergeOrderBuffers.compute.");
-                else
-                {
-                    m_kernelPackOrders        = mergeShader.FindKernel("PackRendererOrders");
-                    m_kernelMergeTwo          = mergeShader.FindKernel("MergeTwo");
-                    m_kernelMergeTwoWithDepth = mergeShader.FindKernel("MergeTwoWithDepth");
-                }
-            }
-            if (copyShader)
-            {
-                if (!copyShader.HasKernel("CopyUint4"))
-                    Debug.LogError($"[GsplatSorter] CopyBufferShader '{copyShader.name}' is missing kernel 'CopyUint4' — assign GsplatCopyBuffer.compute.");
-                else
-                {
-                    m_kernelCopyUint4 = copyShader.FindKernel("CopyUint4");
-                    m_kernelCopyUint2 = copyShader.FindKernel("CopyUint2");
-                }
-            }
-
-            m_globalBuffersDirty = true;
+            m_globalRenderer.InitGlobal(globalMaterial);
         }
 
-        // -----------------------------------------------------------------------
-        // Registration
-        // -----------------------------------------------------------------------
         public void RegisterGsplat(IGsplat gsplat)
         {
             if (m_gsplats.Count == 0)
@@ -257,7 +101,7 @@ namespace Gsplat
             }
 
             m_gsplats.Add(gsplat);
-            m_globalBuffersDirty = true;
+            m_globalRenderer.MarkGlobalBuffersDirty();
         }
 
         public void UnregisterGsplat(IGsplat gsplat)
@@ -268,7 +112,7 @@ namespace Gsplat
             if (gsplat is UnityEngine.Object obj)
                 m_warnedUncompressed.Remove(obj.GetInstanceID());
 
-            m_globalBuffersDirty = true;
+            m_globalRenderer.MarkGlobalBuffersDirty();
 
             if (m_gsplats.Count != 0) return;
 
@@ -284,12 +128,9 @@ namespace Gsplat
             m_commandBuffer?.Dispose();
             m_commandBuffer = null;
             Camera.onPreCull -= OnPreCullCamera;
-            DisposeGlobalBuffers();
+            m_globalRenderer.DisposeGlobalBuffers();
         }
 
-        // -----------------------------------------------------------------------
-        // Per-frame gather
-        // -----------------------------------------------------------------------
         public bool GatherGsplatsForCamera(Camera cam)
         {
             if (cam.cameraType == CameraType.Preview)
@@ -299,7 +140,7 @@ namespace Gsplat
             foreach (var gs in m_gsplats.Where(gs => gs is { isActiveAndEnabled: true, Valid: true }))
                 m_activeGsplats.Add(gs);
 
-            GlobalRenderEnabled = GlobalValid
+            GlobalRenderEnabled = m_globalRenderer.Valid
                                   && GsplatSettings.Instance.EnableGlobalSort
                                   && m_activeGsplats.Count >= 2
                                   && CanRenderGlobally();
@@ -314,24 +155,27 @@ namespace Gsplat
             // renderer_id is packed into 8 bits ([31:24]); max 255 renderers.
             if (m_activeGsplats.Count > 255)
             {
-                Debug.LogError("[GsplatSorter] Global merge supports at most 255 renderers. Falling back to per-renderer rendering.");
+                Debug.LogError(
+                    "[GsplatSorter] Global merge supports at most 255 renderers. Falling back to per-renderer rendering.");
                 return false;
             }
 
             // Global merge requires every active renderer to use SPARK compression.
             foreach (var gs in m_activeGsplats)
             {
-                if (gs.PackedSplatsBuffer == null)
-                {
-                    var obj = gs as UnityEngine.Object;
-                    int id  = obj ? obj.GetInstanceID() : 0;
-                    if (m_warnedUncompressed.Add(id))
-                        Debug.LogWarning($"[GsplatSorter] '{obj?.name}' uses an uncompressed asset; global sort requires every active renderer to use SPARK compression. Disabling global sort for this scene — all renderers fall back to per-renderer rendering.");
-                    return false;
-                }
+                if (gs.GsplatResource is GsplatResourceSpark) continue;
+                var obj = gs as UnityEngine.Object;
+                var id = obj ? obj.GetInstanceID() : 0;
+                if (m_warnedUncompressed.Add(id))
+                    Debug.LogWarning(
+                        $"[GsplatSorter] '{obj?.name}' uses an uncompressed asset; global sort requires every active renderer to use SPARK compression. Disabling global sort for this scene — all renderers fall back to per-renderer rendering.");
+                return false;
             }
+
             return true;
         }
+
+        public void MarkGlobalBuffersDirty() => m_globalRenderer.MarkGlobalBuffersDirty();
 
         void InitialClearCmdBuffer(Camera cam)
         {
@@ -353,9 +197,7 @@ namespace Gsplat
 
             InitialClearCmdBuffer(camera);
             DispatchSort(m_commandBuffer, camera);
-
-            if (GlobalRenderEnabled)
-                DrawAll(m_commandBuffer, camera);
+            DrawAllIfEnabled(m_commandBuffer, camera);
         }
 
         // -----------------------------------------------------------------------
@@ -370,6 +212,7 @@ namespace Gsplat
                 if (gs.RemainingCount <= 0) continue;
                 gs.ComputeDepth(cmd, camera.worldToCameraMatrix * gs.transform.localToWorldMatrix);
             }
+
             cmd.EndSample(k_samplerDepth.name);
 
             // --- Per-renderer radix sort ---
@@ -395,383 +238,24 @@ namespace Gsplat
                     Resources = res.Resources
                 });
             }
+
             cmd.EndSample(k_samplerSort.name);
 
             // --- Global K-way merge ---
             if (!GlobalRenderEnabled) return;
 
-            cmd.BeginSample(k_samplerMerge.name);
-            EnsureGlobalBuffers(cmd);
-            // If EnsureGlobalBuffers failed (uncompressed asset, >255 renderers, etc.),
-            // m_globalOrderBuffer is null. Disable global mode so per-renderer Render()
-            // is not skipped next frame while nothing actually draws.
-            if (m_globalOrderBuffer == null)
-            {
-                GlobalRenderEnabled = false;
-                cmd.EndSample(k_samplerMerge.name);
-                return;
-            }
-            UpdateRendererTransforms();
-            UpdateRendererParams();
-            DispatchMerge(cmd);
-            cmd.EndSample(k_samplerMerge.name);
+            m_globalRenderer.Dispatch(cmd, m_activeGsplats);
         }
 
-        // -----------------------------------------------------------------------
-        // Global buffer management
-        // -----------------------------------------------------------------------
-        void EnsureGlobalBuffers(CommandBuffer cmd)
-        {
-            // A renderer streaming in its splats via async upload (AsyncUpload +
-            // RenderBeforeUploadComplete) grows its SplatCount frame to frame. Rebuild when an
-            // active renderer's count no longer matches what we last built with, otherwise the
-            // global sub-ranges keep only the splats present at the first build and the rest are
-            // never copied in (leaving the merge to read stale/under-sized global buffers).
-            if (!m_globalBuffersDirty && ActiveSplatCountsChanged())
-                m_globalBuffersDirty = true;
-
-            if (!m_globalBuffersDirty) return;
-            m_globalBuffersDirty = false;
-
-            DisposeGlobalBuffers();
-
-            m_totalSplatCount = 0;
-            m_rendererOffsets  = new uint[m_activeGsplats.Count];
-            m_builtSplatCounts = new uint[m_activeGsplats.Count];
-            // Size SH buffers to the highest band count in the set; lower-band renderers
-            // occupy the extra slots but never read them, since each renderer's SHDegree is
-            // clamped to its own asset bands in UpdateRendererParams.
-            m_globalSHBands   = 0;
-
-            foreach (var gs in m_activeGsplats)
-                if (gs.SHBands > m_globalSHBands) m_globalSHBands = gs.SHBands;
-
-            for (int k = 0; k < m_activeGsplats.Count; k++)
-            {
-                uint count = m_activeGsplats[k].SplatCount;
-                m_rendererOffsets[k]  = m_totalSplatCount;
-                m_builtSplatCounts[k] = count;
-                m_totalSplatCount    += count;
-            }
-
-            if (m_totalSplatCount == 0) return;
-
-            // CanRenderGlobally() in Gather already guarded count<=255 and Spark-only;
-            // GlobalRenderEnabled would be false and we wouldn't be here otherwise.
-
-            var st = GraphicsBuffer.Target.Structured;
-            m_globalPackedBuffer       = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4) { name = "Gsplat.GlobalPacked" };
-            m_globalOrderBuffer        = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))     { name = "Gsplat.GlobalOrder" };
-            m_rendererOffsetsBuffer    = new GraphicsBuffer(st, m_activeGsplats.Count,  sizeof(uint))     { name = "Gsplat.RendererOffsets" };
-            m_rendererTransformsBuffer = new GraphicsBuffer(st, m_activeGsplats.Count,  sizeof(float)*16) { name = "Gsplat.RendererTransforms" };
-            m_rendererParamsBuffer     = new GraphicsBuffer(st, m_activeGsplats.Count,  sizeof(float)*2 + sizeof(uint)*2) { name = "Gsplat.RendererParams" };
-
-            if (m_globalSHBands >= 1)
-                m_globalSH1Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 2) { name = "Gsplat.GlobalSH1" };
-            if (m_globalSHBands >= 2)
-                m_globalSH2Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4) { name = "Gsplat.GlobalSH2" };
-            if (m_globalSHBands >= 3)
-                m_globalSH3Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4) { name = "Gsplat.GlobalSH3" };
-            if (m_globalSHBands >= 4)
-                m_globalSH4Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4) { name = "Gsplat.GlobalSH4" };
-
-            m_rendererOffsetsBuffer.SetData(m_rendererOffsets);
-
-            // Copy per-renderer packed splat data into global buffer sub-ranges.
-            for (int k = 0; k < m_activeGsplats.Count; k++)
-            {
-                var gs     = m_activeGsplats[k];
-                uint count = gs.SplatCount;
-                uint off   = m_rendererOffsets[k];
-                if (count == 0) continue;
-
-                CopyUint4(cmd, gs.PackedSplatsBuffer, m_globalPackedBuffer, count, off);
-                if (m_globalSHBands >= 1 && gs.SH1Buffer != null)
-                    CopyUint2(cmd, gs.SH1Buffer, m_globalSH1Buffer, count, off);
-                if (m_globalSHBands >= 2 && gs.SH2Buffer != null)
-                    CopyUint4(cmd, gs.SH2Buffer, m_globalSH2Buffer, count, off);
-                if (m_globalSHBands >= 3 && gs.SH3Buffer != null)
-                    CopyUint4(cmd, gs.SH3Buffer, m_globalSH3Buffer, count, off);
-                if (m_globalSHBands >= 4 && gs.SH4Buffer != null)
-                    CopyUint4(cmd, gs.SH4Buffer, m_globalSH4Buffer, count, off);
-            }
-
-            // Allocate merge scratch buffers (always fresh after a dirty rebuild).
-            m_packScratchOrders  = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))  { name = "Gsplat.PackScratchOrders" };
-            m_packScratchDepths  = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(float)) { name = "Gsplat.PackScratchDepths" };
-            m_mergeScratchOrders = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))  { name = "Gsplat.MergeScratchOrders" };
-            m_mergeScratchDepths = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(float)) { name = "Gsplat.MergeScratchDepths" };
-            m_scratchCapacity    = m_totalSplatCount;
-        }
-
-        // True when an active renderer's SplatCount no longer matches what the global buffers were
-        // built with (e.g. an async upload has streamed in more splats since the last rebuild).
-        // Active-set size changes are already covered by MarkGlobalBuffersDirty on register/unregister.
-        bool ActiveSplatCountsChanged()
-        {
-            if (m_builtSplatCounts == null || m_builtSplatCounts.Length != m_activeGsplats.Count)
-                return true;
-            for (int k = 0; k < m_activeGsplats.Count; k++)
-                if (m_builtSplatCounts[k] != m_activeGsplats[k].SplatCount)
-                    return true;
-            return false;
-        }
-
-        void UpdateRendererTransforms()
-        {
-            if (m_rendererTransformsBuffer == null) return;
-            int count = m_activeGsplats.Count;
-            if (m_rendererTransformsCache == null || m_rendererTransformsCache.Length != count)
-                m_rendererTransformsCache = new Matrix4x4[count];
-            for (int k = 0; k < count; k++)
-                m_rendererTransformsCache[k] = m_activeGsplats[k].transform.localToWorldMatrix;
-            m_rendererTransformsBuffer.SetData(m_rendererTransformsCache);
-        }
-
-        void UpdateRendererParams()
-        {
-            if (m_rendererParamsBuffer == null) return;
-            int count = m_activeGsplats.Count;
-            if (m_rendererParamsCache == null || m_rendererParamsCache.Length != count)
-                m_rendererParamsCache = new RendererParams[count];
-            for (int k = 0; k < count; k++)
-            {
-                var gs = m_activeGsplats[k] as GsplatRenderer;
-                if (gs != null)
-                {
-                    m_rendererParamsCache[k] = new RendererParams
-                    {
-                        brightness    = gs.Brightness,
-                        scaleFactor   = 1.0f - gs.SplatDownscaleFactor,
-                        gammaToLinear = gs.GammaToLinear ? 1u : 0u,
-                        // Clamp to the asset's own bands so EvalSH never reads slots that
-                        // weren't copied for this renderer (the global buffers are sized to
-                        // the max bands across the set).
-                        shDegree      = (uint)Mathf.Min(gs.SHDegree, m_activeGsplats[k].SHBands),
-                    };
-                }
-                else
-                {
-                    m_rendererParamsCache[k] = new RendererParams
-                    {
-                        brightness    = 1.0f,
-                        scaleFactor   = 1.0f,
-                        gammaToLinear = 0u,
-                        shDegree      = m_activeGsplats[k].SHBands,
-                    };
-                }
-            }
-            m_rendererParamsBuffer.SetData(m_rendererParamsCache);
-        }
-
-        // -----------------------------------------------------------------------
-        // Copy helpers (GPU-side via command buffer)
-        // -----------------------------------------------------------------------
-        void CopyUint4(CommandBuffer cmd, GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
-        {
-            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_srcElementCount,  (int)count);
-            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_dstElementOffset, (int)dstOff);
-            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, k_srcUint4, src);
-            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, k_dstUint4, dst);
-            cmd.DispatchCompute(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
-        }
-
-        void CopyUint2(CommandBuffer cmd, GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
-        {
-            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_srcElementCount,  (int)count);
-            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_dstElementOffset, (int)dstOff);
-            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, k_srcUint2, src);
-            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, k_dstUint2, dst);
-            cmd.DispatchCompute(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
-        }
-
-        // -----------------------------------------------------------------------
-        // Merge dispatch
-        // -----------------------------------------------------------------------
-        void DispatchMerge(CommandBuffer cmd)
-        {
-            int K = m_activeGsplats.Count;
-            if (K < 2 || m_globalOrderBuffer == null) return;
-
-            // Step 1: pack each renderer's sorted orders + depths into m_packScratch.
-            for (int k = 0; k < K; k++)
-            {
-                var gs    = m_activeGsplats[k];
-                if (gs.SorterResource is not Resource res) continue;
-                uint cnt  = gs.RemainingCount;
-                uint off  = m_rendererOffsets[k];
-                if (cnt == 0) continue;
-
-                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_rendererIdx, k);
-                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_srcCount,    (int)cnt);
-                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_dstOffset,   (int)off);
-                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_rawOrders,    res.OrderBuffer);
-                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_rawDepths,    res.InputKeys);
-                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_packedOrders, m_packScratchOrders);
-                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_packedDepths, m_packScratchDepths);
-                cmd.DispatchCompute(m_globalMaterial.MergeShader, m_kernelPackOrders, (int)GsplatUtils.DivRoundUp(cnt, 256), 1, 1);
-            }
-
-            // Step 2: cascaded 2-way merges.
-            // After each pass the merged sub-range grows. We alternate writing between
-            // m_packScratch (treated as read-only source) and m_mergeScratch.
-            // Source for renderer k's sorted range is always m_packScratchOrders[off[k]..off[k]+cnt[k]).
-            // The merged-so-far result alternates between m_mergeScratch and a temporary swap.
-
-            uint mergedCount  = m_activeGsplats[0].RemainingCount;   // size of merged result so far
-            uint mergedOffset = 0;                                    // always at start of its scratch buffer
-
-            // Current merged result lives in: packScratch initially (range [0, mergedCount)).
-            // We swap between packScratch and mergeScratch each pass.
-            bool mergedInPack = true;
-
-            for (int k = 1; k < K; k++)
-            {
-                var gs      = m_activeGsplats[k];
-                uint cntK   = gs.RemainingCount;
-                uint offK   = m_rendererOffsets[k];
-                bool isFinal = (k == K - 1);
-                uint total  = mergedCount + cntK;
-
-                // Source A: current merged result.
-                var srcAOrders = mergedInPack ? m_packScratchOrders : m_mergeScratchOrders;
-                var srcADepths = mergedInPack ? m_packScratchDepths : m_mergeScratchDepths;
-
-                // Source B: renderer k's range in packScratch.
-                // (always in packScratch regardless of which buffer holds merged result)
-                var srcBOrders = m_packScratchOrders;
-                var srcBDepths = m_packScratchDepths;
-
-                // Destination: final pass → globalOrderBuffer; otherwise the other scratch.
-                GraphicsBuffer dstOrders, dstDepths;
-                if (isFinal)
-                {
-                    dstOrders = m_globalOrderBuffer;
-                    dstDepths = null;
-                }
-                else
-                {
-                    dstOrders = mergedInPack ? m_mergeScratchOrders : m_packScratchOrders;
-                    dstDepths = mergedInPack ? m_mergeScratchDepths : m_packScratchDepths;
-                }
-
-                int kernel = isFinal ? m_kernelMergeTwo : m_kernelMergeTwoWithDepth;
-
-                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_offsetA,      (int)mergedOffset);
-                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_offsetB,      (int)offK);
-                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_countA,       (int)mergedCount);
-                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_countB,       (int)cntK);
-                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_outputOffset,  0);
-                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_depthsA,      srcADepths);
-                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_ordersA,      srcAOrders);
-                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_depthsB,      srcBDepths);
-                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_ordersB,      srcBOrders);
-                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_outputOrders, dstOrders);
-                if (!isFinal)
-                    cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_outputDepths, dstDepths);
-
-                cmd.DispatchCompute(m_globalMaterial.MergeShader, kernel, (int)GsplatUtils.DivRoundUp(total, 256), 1, 1);
-
-                mergedCount  = total;
-                mergedOffset = 0;           // output always starts at 0 in the destination buffer
-                mergedInPack = !mergedInPack;
-            }
-
-            m_totalRemainingCount = mergedCount;
-        }
-
-        // -----------------------------------------------------------------------
-        // Global draw call
-        // -----------------------------------------------------------------------
         public void DrawAllIfEnabled(CommandBuffer cmd, Camera camera)
         {
             if (GlobalRenderEnabled)
-                DrawAll(cmd, camera);
+                m_globalRenderer.DrawAll(cmd, camera);
         }
 
-        void DrawAll(CommandBuffer cmd, Camera camera)
-        {
-            // m_globalBuffersDirty: the active renderer set changed and the next DispatchSort
-            // hasn't validated/rebuilt the buffers yet. Drawing now would bind stale buffers
-            // (under URP, DrawAllIfEnabled fires before DispatchSort each frame).
-            if (m_globalBuffersDirty || m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
-
-            cmd?.BeginSample(k_samplerDraw.name);
-
-            var mat = m_globalMaterial.Materials[m_globalSHBands];
-
-            // Bind buffers via a MaterialPropertyBlock rather than on the material itself, so
-            // each queued draw captures its own bindings and multiple cameras (Game + SceneView,
-            // or any multi-camera setup) don't overwrite one another's state before the GPU
-            // executes them.
-            m_globalPropertyBlock ??= new MaterialPropertyBlock();
-            m_globalPropertyBlock.Clear();
-            m_globalPropertyBlock.SetBuffer(k_globalOrderBuffer,      m_globalOrderBuffer);
-            m_globalPropertyBlock.SetBuffer(k_globalPackedBuffer,     m_globalPackedBuffer);
-            m_globalPropertyBlock.SetBuffer(k_rendererOffsetsProp,    m_rendererOffsetsBuffer);
-            m_globalPropertyBlock.SetBuffer(k_rendererTransformsProp, m_rendererTransformsBuffer);
-            m_globalPropertyBlock.SetBuffer(k_rendererParamsProp,     m_rendererParamsBuffer);
-            m_globalPropertyBlock.SetInteger(k_totalSplatCount,       (int)m_totalRemainingCount);
-            m_globalPropertyBlock.SetInteger(k_splatInstanceSize,     (int)GsplatSettings.Instance.SplatInstanceSize);
-
-            if (m_globalSH1Buffer != null)
-                m_globalPropertyBlock.SetBuffer(k_globalSH1Buffer, m_globalSH1Buffer);
-            if (m_globalSH2Buffer != null)
-                m_globalPropertyBlock.SetBuffer(k_globalSH2Buffer, m_globalSH2Buffer);
-            if (m_globalSH3Buffer != null)
-                m_globalPropertyBlock.SetBuffer(k_globalSH3Buffer, m_globalSH3Buffer);
-            if (m_globalSH4Buffer != null)
-                m_globalPropertyBlock.SetBuffer(k_globalSH4Buffer, m_globalSH4Buffer);
-
-            var rp = new RenderParams(mat)
-            {
-                worldBounds = new Bounds(Vector3.zero, Vector3.one * 1e6f),
-                camera      = camera,
-                matProps    = m_globalPropertyBlock
-            };
-
-            int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
-            Graphics.RenderMeshPrimitives(rp, GsplatSettings.Instance.Mesh, 0, instances);
-
-            cmd?.EndSample(k_samplerDraw.name);
-        }
-
-        // -----------------------------------------------------------------------
-        // Cleanup
-        // -----------------------------------------------------------------------
-        void DisposeGlobalBuffers()
-        {
-            m_globalPackedBuffer?.Dispose();        m_globalPackedBuffer       = null;
-            m_globalSH1Buffer?.Dispose();           m_globalSH1Buffer          = null;
-            m_globalSH2Buffer?.Dispose();           m_globalSH2Buffer          = null;
-            m_globalSH3Buffer?.Dispose();           m_globalSH3Buffer          = null;
-            m_globalSH4Buffer?.Dispose();           m_globalSH4Buffer          = null;
-            m_globalOrderBuffer?.Dispose();         m_globalOrderBuffer        = null;
-            m_rendererOffsetsBuffer?.Dispose();     m_rendererOffsetsBuffer    = null;
-            m_rendererTransformsBuffer?.Dispose();  m_rendererTransformsBuffer = null;
-            m_rendererParamsBuffer?.Dispose();      m_rendererParamsBuffer     = null;
-            // Scratch buffers are rebuilt every time global buffers are rebuilt,
-            // so dispose them here too to avoid leaking when renderer count shrinks.
-            m_packScratchOrders?.Dispose();         m_packScratchOrders        = null;
-            m_packScratchDepths?.Dispose();         m_packScratchDepths        = null;
-            m_mergeScratchOrders?.Dispose();        m_mergeScratchOrders       = null;
-            m_mergeScratchDepths?.Dispose();        m_mergeScratchDepths       = null;
-            m_scratchCapacity = 0;
-            // Drop the build snapshot so the next EnsureGlobalBuffers re-captures counts from scratch.
-            m_builtSplatCounts = null;
-        }
-
-        // -----------------------------------------------------------------------
-        // Public API
-        // -----------------------------------------------------------------------
         public ISorterResource CreateSorterResource(uint count, GraphicsBuffer orderBuffer)
         {
             return new Resource(count, orderBuffer);
         }
-
-        /// <summary>
-        /// Call when a renderer's asset changes so the global packed buffer is rebuilt next frame.
-        /// </summary>
-        public void MarkGlobalBuffersDirty() => m_globalBuffersDirty = true;
     }
 }

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -288,8 +288,38 @@ namespace Gsplat
             foreach (var gs in m_gsplats.Where(gs => gs is { isActiveAndEnabled: true, Valid: true }))
                 m_activeGsplats.Add(gs);
 
-            GlobalRenderEnabled = GlobalValid && GsplatSettings.Instance.EnableGlobalSort && m_activeGsplats.Count >= 2;
+            GlobalRenderEnabled = GlobalValid
+                                  && GsplatSettings.Instance.EnableGlobalSort
+                                  && m_activeGsplats.Count >= 2
+                                  && CanRenderGlobally();
             return m_activeGsplats.Count != 0;
+        }
+
+        // Decides scene-wide whether the global merge can run this frame. Must run before
+        // DrawAllIfEnabled (which the URP feature calls in OnCameraPreCull, before DispatchSort)
+        // so that the draw is correctly suppressed when global mode is unsupported.
+        bool CanRenderGlobally()
+        {
+            // renderer_id is packed into 8 bits ([31:24]); max 255 renderers.
+            if (m_activeGsplats.Count > 255)
+            {
+                Debug.LogError("[GsplatSorter] Global merge supports at most 255 renderers. Falling back to per-renderer rendering.");
+                return false;
+            }
+
+            // Global merge requires every active renderer to use SPARK compression.
+            foreach (var gs in m_activeGsplats)
+            {
+                if (gs.PackedSplatsBuffer == null)
+                {
+                    var obj = gs as UnityEngine.Object;
+                    int id  = obj ? obj.GetInstanceID() : 0;
+                    if (m_warnedUncompressed.Add(id))
+                        Debug.LogWarning($"[GsplatSorter] '{obj?.name}' uses an uncompressed asset; global sort requires every active renderer to use SPARK compression. Disabling global sort for this scene — all renderers fall back to per-renderer rendering.");
+                    return false;
+                }
+            }
+            return true;
         }
 
         void InitialClearCmdBuffer(Camera cam)
@@ -400,27 +430,8 @@ namespace Gsplat
 
             if (m_totalSplatCount == 0) return;
 
-            // Guard: renderer_id is packed into 8 bits ([31:24]); max 255 renderers.
-            if (m_activeGsplats.Count > 255)
-            {
-                Debug.LogError("[GsplatSorter] Global merge supports at most 255 renderers. Falling back to per-renderer rendering.");
-                m_globalBuffersDirty = true;
-                return;
-            }
-
-            // Guard: global merge only supports SPARK-compressed assets.
-            foreach (var gs in m_activeGsplats)
-            {
-                if (gs.PackedSplatsBuffer == null)
-                {
-                    var obj = gs as UnityEngine.Object;
-                    int id  = obj ? obj.GetInstanceID() : 0;
-                    if (m_warnedUncompressed.Add(id))
-                        Debug.LogWarning($"[GsplatSorter] '{obj?.name}' uses an uncompressed asset; global sort requires SPARK compression. Falling back to per-renderer rendering for this renderer.");
-                    m_globalBuffersDirty = true;
-                    return;
-                }
-            }
+            // CanRenderGlobally() in Gather already guarded count<=255 and Spark-only;
+            // GlobalRenderEnabled would be false and we wouldn't be here otherwise.
 
             var st = GraphicsBuffer.Target.Structured;
             m_globalPackedBuffer       = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4) { name = "Gsplat.GlobalPacked" };
@@ -604,7 +615,10 @@ namespace Gsplat
 
         void DrawAll(CommandBuffer cmd, Camera camera)
         {
-            if (m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
+            // m_globalBuffersDirty: the active renderer set changed and the next DispatchSort
+            // hasn't validated/rebuilt the buffers yet. Drawing now would bind stale buffers
+            // (under URP, DrawAllIfEnabled fires before DispatchSort each frame).
+            if (m_globalBuffersDirty || m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
 
             cmd?.BeginSample(k_samplerDraw.name);
 

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -140,16 +140,10 @@ namespace Gsplat
             foreach (var gs in m_gsplats.Where(gs => gs is { isActiveAndEnabled: true, Valid: true }))
                 m_activeGsplats.Add(gs);
 
-            GlobalRenderEnabled = m_globalRenderer.Valid
-                                  && GsplatSettings.Instance.EnableGlobalSort
-                                  && m_activeGsplats.Count >= 2
-                                  && CanRenderGlobally();
             return m_activeGsplats.Count != 0;
         }
 
-        // Decides scene-wide whether the global merge can run this frame. Must run before
-        // DrawAllIfEnabled (which the URP feature calls in OnCameraPreCull, before DispatchSort)
-        // so that the draw is correctly suppressed when global mode is unsupported.
+        // Decides scene-wide whether the global merge can run this frame. 
         bool CanRenderGlobally()
         {
             // renderer_id is packed into 8 bits ([31:24]); max 255 renderers.
@@ -197,12 +191,8 @@ namespace Gsplat
 
             InitialClearCmdBuffer(camera);
             DispatchSort(m_commandBuffer, camera);
-            DrawAllIfEnabled(m_commandBuffer, camera);
         }
 
-        // -----------------------------------------------------------------------
-        // Sort dispatch (with profiling markers)
-        // -----------------------------------------------------------------------
         public void DispatchSort(CommandBuffer cmd, Camera camera)
         {
             // --- Per-renderer depth computation ---
@@ -242,15 +232,22 @@ namespace Gsplat
             cmd.EndSample(k_samplerSort.name);
 
             // --- Global K-way merge ---
-            if (!GlobalRenderEnabled) return;
-
-            m_globalRenderer.Dispatch(cmd, m_activeGsplats);
+            if (GlobalRenderEnabled)
+                m_globalRenderer.DispatchMerge(cmd, m_activeGsplats);
         }
 
-        public void DrawAllIfEnabled(CommandBuffer cmd, Camera camera)
+        // Called by GsplatPlayerLoopHook once per frame, before Unity's PostLateUpdate phase
+        public void Update()
         {
-            if (GlobalRenderEnabled)
-                m_globalRenderer.DrawAll(cmd, camera);
+            GlobalRenderEnabled = m_globalRenderer.Valid && GsplatSettings.Instance.EnableGlobalSort &&
+                                  m_activeGsplats.Count >= 2;
+            if (!GlobalRenderEnabled) return;
+            m_activeGsplats.Clear();
+            foreach (var gs in m_gsplats.Where(gs => gs is { isActiveAndEnabled: true, Valid: true }))
+                m_activeGsplats.Add(gs);
+            GlobalRenderEnabled = GlobalRenderEnabled && CanRenderGlobally();
+            if (!GlobalRenderEnabled) return;
+            m_globalRenderer.Update(m_activeGsplats);
         }
 
         public ISorterResource CreateSorterResource(uint count, GraphicsBuffer orderBuffer)

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) 2025 Yize Wu
+// Copyright (c) 2026 Keir Rice
 // SPDX-License-Identifier: MIT
 
 using System.Collections.Generic;
@@ -17,6 +18,15 @@ namespace Gsplat
         public bool Valid { get; }
         public bool ComputeSortRequired { get; }
         public void ComputeDepth(CommandBuffer cmd, Matrix4x4 matrixMv);
+
+        // Used by GsplatSorter to populate the global packed buffer.
+        public GraphicsBuffer PackedSplatsBuffer { get; }
+        public GraphicsBuffer SH1Buffer { get; }
+        public GraphicsBuffer SH2Buffer { get; }
+        public GraphicsBuffer SH3Buffer { get; }
+        public GraphicsBuffer SH4Buffer { get; }
+        public uint SplatCount { get; }
+        public byte SHBands { get; }
     }
 
     public interface ISorterResource
@@ -55,22 +65,178 @@ namespace Gsplat
             }
         }
 
+        // -----------------------------------------------------------------------
+        // Singleton
+        // -----------------------------------------------------------------------
         public static GsplatSorter Instance => s_instance ??= new GsplatSorter();
         static GsplatSorter s_instance;
+
         CommandBuffer m_commandBuffer;
         readonly HashSet<IGsplat> m_gsplats = new();
         readonly HashSet<Camera> m_camerasInjected = new();
         readonly List<IGsplat> m_activeGsplats = new();
+        readonly HashSet<int> m_warnedUncompressed = new();
         GsplatSortPass m_sortPass;
         public const string k_PassName = "SortGsplats";
 
+        // -----------------------------------------------------------------------
+        // Global merge state
+        // -----------------------------------------------------------------------
+        GsplatGlobalMaterial m_globalMaterial;
+
+        int m_kernelPackOrders        = -1;
+        int m_kernelMergeTwo          = -1;
+        int m_kernelMergeTwoWithDepth = -1;
+        int m_kernelCopyUint4         = -1;
+        int m_kernelCopyUint2         = -1;
+
+        // CPU-side per-renderer metadata (rebuilt when renderers change).
+        uint[] m_rendererOffsets;   // splat start index in global buffers, per active renderer
+        uint   m_totalSplatCount;
+        uint   m_totalRemainingCount; // sum of RemainingCounts; valid entries in GlobalOrderBuffer after merge
+        byte   m_globalSHBands;
+        bool   m_globalBuffersDirty = true;
+
+        // Global packed data buffers (sub-ranges owned by each renderer).
+        GraphicsBuffer m_globalPackedBuffer;
+        GraphicsBuffer m_globalSH1Buffer;
+        GraphicsBuffer m_globalSH2Buffer;
+        GraphicsBuffer m_globalSH3Buffer;
+        GraphicsBuffer m_globalSH4Buffer;
+        GraphicsBuffer m_globalOrderBuffer;
+        GraphicsBuffer m_rendererOffsetsBuffer;
+        GraphicsBuffer m_rendererTransformsBuffer;
+
+        // Scratch buffers for merge passes.
+        // m_packScratch*  : all renderers' orders+depths packed and concatenated.
+        // m_mergeScratch* : ping-pong pair for cascaded intermediate merges.
+        GraphicsBuffer m_packScratchOrders;
+        GraphicsBuffer m_packScratchDepths;
+        GraphicsBuffer m_mergeScratchOrders;
+        GraphicsBuffer m_mergeScratchDepths;
+        uint           m_scratchCapacity;
+        Matrix4x4[]    m_rendererTransformsCache;
+
+        /// <summary>True when 2+ active renderers are being globally merged this frame.</summary>
+        public bool GlobalRenderEnabled { get; private set; }
+
+        // -----------------------------------------------------------------------
+        // Profiling samplers
+        // -----------------------------------------------------------------------
+        static readonly ProfilingSampler k_samplerDepth = new("Gsplat.DepthPerRenderer");
+        static readonly ProfilingSampler k_samplerSort  = new("Gsplat.SortPerRenderer");
+        static readonly ProfilingSampler k_samplerMerge = new("Gsplat.MergeKWay");
+        static readonly ProfilingSampler k_samplerDraw  = new("Gsplat.DrawAll");
+
+        // -----------------------------------------------------------------------
+        // Shader property IDs — merge / pack
+        // -----------------------------------------------------------------------
+        static readonly int k_rawOrders      = Shader.PropertyToID("_RawOrders");
+        static readonly int k_rawDepths      = Shader.PropertyToID("_RawDepths");
+        static readonly int k_packedOrders   = Shader.PropertyToID("_PackedOrders");
+        static readonly int k_packedDepths   = Shader.PropertyToID("_PackedDepths");
+        static readonly int k_rendererIdx    = Shader.PropertyToID("_RendererIdx");
+        static readonly int k_srcCount       = Shader.PropertyToID("_SrcCount");
+        static readonly int k_dstOffset      = Shader.PropertyToID("_DstOffset");
+
+        static readonly int k_depthsA        = Shader.PropertyToID("_DepthsA");
+        static readonly int k_ordersA        = Shader.PropertyToID("_OrdersA");
+        static readonly int k_depthsB        = Shader.PropertyToID("_DepthsB");
+        static readonly int k_ordersB        = Shader.PropertyToID("_OrdersB");
+        static readonly int k_offsetA        = Shader.PropertyToID("_OffsetA");
+        static readonly int k_offsetB        = Shader.PropertyToID("_OffsetB");
+        static readonly int k_countA         = Shader.PropertyToID("_CountA");
+        static readonly int k_countB         = Shader.PropertyToID("_CountB");
+        static readonly int k_outputOffset   = Shader.PropertyToID("_OutputOffset");
+        static readonly int k_outputOrders   = Shader.PropertyToID("_OutputOrders");
+        static readonly int k_outputDepths   = Shader.PropertyToID("_OutputDepths");
+
+        // Copy kernel IDs
+        static readonly int k_srcUint4         = Shader.PropertyToID("_SrcUint4");
+        static readonly int k_dstUint4         = Shader.PropertyToID("_DstUint4");
+        static readonly int k_srcUint2         = Shader.PropertyToID("_SrcUint2");
+        static readonly int k_dstUint2         = Shader.PropertyToID("_DstUint2");
+        static readonly int k_srcElementCount  = Shader.PropertyToID("_SrcElementCount");
+        static readonly int k_dstElementOffset = Shader.PropertyToID("_DstElementOffset");
+
+        // Global draw material properties
+        static readonly int k_globalOrderBuffer      = Shader.PropertyToID("_GlobalOrderBuffer");
+        static readonly int k_globalPackedBuffer     = Shader.PropertyToID("_GlobalPackedBuffer");
+        static readonly int k_globalSH1Buffer        = Shader.PropertyToID("_GlobalSH1Buffer");
+        static readonly int k_globalSH2Buffer        = Shader.PropertyToID("_GlobalSH2Buffer");
+        static readonly int k_globalSH3Buffer        = Shader.PropertyToID("_GlobalSH3Buffer");
+        static readonly int k_globalSH4Buffer        = Shader.PropertyToID("_GlobalSH4Buffer");
+        static readonly int k_shDegree               = Shader.PropertyToID("_SHDegree");
+        static readonly int k_rendererOffsetsProp    = Shader.PropertyToID("_RendererOffsets");
+        static readonly int k_rendererTransformsProp = Shader.PropertyToID("_RendererTransforms");
+        static readonly int k_totalSplatCount        = Shader.PropertyToID("_TotalSplatCount");
+        static readonly int k_splatInstanceSize      = Shader.PropertyToID("_SplatInstanceSize");
+        static readonly int k_brightness             = Shader.PropertyToID("_Brightness");
+        static readonly int k_scaleFactor            = Shader.PropertyToID("_ScaleFactor");
+        static readonly int k_gammaToLinear          = Shader.PropertyToID("_GammaToLinear");
+
+        // -----------------------------------------------------------------------
+        // Validity
+        // -----------------------------------------------------------------------
         public bool Valid => m_sortPass is { Valid: true };
 
+        bool GlobalValid => m_globalMaterial
+                           && m_globalMaterial.MergeShader && m_globalMaterial.CopyBufferShader
+                           && m_globalMaterial.DefaultMaterial
+                           && m_kernelPackOrders >= 0
+                           && m_kernelMergeTwo >= 0
+                           && m_kernelMergeTwoWithDepth >= 0
+                           && m_kernelCopyUint4 >= 0
+                           && m_kernelCopyUint2 >= 0;
+
+        // -----------------------------------------------------------------------
+        // Init
+        // -----------------------------------------------------------------------
         public void InitSorter(ComputeShader computeShader)
         {
             m_sortPass = computeShader ? new GsplatSortPass(computeShader) : null;
         }
 
+        public void InitGlobal(GsplatGlobalMaterial globalMaterial)
+        {
+            m_globalMaterial     = globalMaterial;
+            m_kernelPackOrders   = -1;
+            m_kernelMergeTwo     = -1;
+            m_kernelMergeTwoWithDepth = -1;
+            m_kernelCopyUint4    = -1;
+            m_kernelCopyUint2    = -1;
+
+            var mergeShader = globalMaterial ? globalMaterial.MergeShader : null;
+            var copyShader  = globalMaterial ? globalMaterial.CopyBufferShader : null;
+
+            if (mergeShader)
+            {
+                if (!mergeShader.HasKernel("PackRendererOrders"))
+                    Debug.LogError($"[GsplatSorter] MergeShader '{mergeShader.name}' is missing kernel 'PackRendererOrders' — assign GsplatMergeOrderBuffers.compute.");
+                else
+                {
+                    m_kernelPackOrders        = mergeShader.FindKernel("PackRendererOrders");
+                    m_kernelMergeTwo          = mergeShader.FindKernel("MergeTwo");
+                    m_kernelMergeTwoWithDepth = mergeShader.FindKernel("MergeTwoWithDepth");
+                }
+            }
+            if (copyShader)
+            {
+                if (!copyShader.HasKernel("CopyUint4"))
+                    Debug.LogError($"[GsplatSorter] CopyBufferShader '{copyShader.name}' is missing kernel 'CopyUint4' — assign GsplatCopyBuffer.compute.");
+                else
+                {
+                    m_kernelCopyUint4 = copyShader.FindKernel("CopyUint4");
+                    m_kernelCopyUint2 = copyShader.FindKernel("CopyUint2");
+                }
+            }
+
+            m_globalBuffersDirty = true;
+        }
+
+        // -----------------------------------------------------------------------
+        // Registration
+        // -----------------------------------------------------------------------
         public void RegisterGsplat(IGsplat gsplat)
         {
             if (m_gsplats.Count == 0)
@@ -80,12 +246,19 @@ namespace Gsplat
             }
 
             m_gsplats.Add(gsplat);
+            m_globalBuffersDirty = true;
         }
 
         public void UnregisterGsplat(IGsplat gsplat)
         {
             if (!m_gsplats.Remove(gsplat))
                 return;
+
+            if (gsplat is UnityEngine.Object obj)
+                m_warnedUncompressed.Remove(obj.GetInstanceID());
+
+            m_globalBuffersDirty = true;
+
             if (m_gsplats.Count != 0) return;
 
             if (m_camerasInjected != null)
@@ -100,8 +273,12 @@ namespace Gsplat
             m_commandBuffer?.Dispose();
             m_commandBuffer = null;
             Camera.onPreCull -= OnPreCullCamera;
+            DisposeGlobalBuffers();
         }
 
+        // -----------------------------------------------------------------------
+        // Per-frame gather
+        // -----------------------------------------------------------------------
         public bool GatherGsplatsForCamera(Camera cam)
         {
             if (cam.cameraType == CameraType.Preview)
@@ -110,6 +287,8 @@ namespace Gsplat
             m_activeGsplats.Clear();
             foreach (var gs in m_gsplats.Where(gs => gs is { isActiveAndEnabled: true, Valid: true }))
                 m_activeGsplats.Add(gs);
+
+            GlobalRenderEnabled = GlobalValid && GsplatSettings.Instance.EnableGlobalSort && m_activeGsplats.Count >= 2;
             return m_activeGsplats.Count != 0;
         }
 
@@ -133,14 +312,30 @@ namespace Gsplat
 
             InitialClearCmdBuffer(camera);
             DispatchSort(m_commandBuffer, camera);
+
+            if (GlobalRenderEnabled)
+                DrawAll(m_commandBuffer, camera);
         }
 
+        // -----------------------------------------------------------------------
+        // Sort dispatch (with profiling markers)
+        // -----------------------------------------------------------------------
         public void DispatchSort(CommandBuffer cmd, Camera camera)
         {
+            // --- Per-renderer depth computation ---
+            cmd.BeginSample(k_samplerDepth.name);
             foreach (var gs in m_activeGsplats)
             {
-                var res = (Resource)gs.SorterResource;
+                if (gs.RemainingCount <= 0) continue;
+                gs.ComputeDepth(cmd, camera.worldToCameraMatrix * gs.transform.localToWorldMatrix);
+            }
+            cmd.EndSample(k_samplerDepth.name);
 
+            // --- Per-renderer radix sort ---
+            cmd.BeginSample(k_samplerSort.name);
+            foreach (var gs in m_activeGsplats)
+            {
+                if (gs.SorterResource is not Resource res) continue;
                 if (!gs.ComputeSortRequired || gs.RemainingCount <= 0)
                     continue;
 
@@ -150,23 +345,341 @@ namespace Gsplat
                     res.Initialized = true;
                 }
 
-                var sorterArgs = new GsplatSortPass.Args
+                m_sortPass.Dispatch(cmd, new GsplatSortPass.Args
                 {
                     Count = gs.RemainingCount,
                     MatrixMv = camera.worldToCameraMatrix * gs.transform.localToWorldMatrix,
                     InputKeys = res.InputKeys,
                     InputValues = res.OrderBuffer,
                     Resources = res.Resources
-                };
-
-                gs.ComputeDepth(cmd, camera.worldToCameraMatrix * gs.transform.localToWorldMatrix);
-                m_sortPass.Dispatch(cmd, sorterArgs);
+                });
             }
+            cmd.EndSample(k_samplerSort.name);
+
+            // --- Global K-way merge ---
+            if (!GlobalRenderEnabled) return;
+
+            cmd.BeginSample(k_samplerMerge.name);
+            EnsureGlobalBuffers(cmd);
+            // If EnsureGlobalBuffers failed (uncompressed asset, >255 renderers, etc.),
+            // m_globalOrderBuffer is null. Disable global mode so per-renderer Render()
+            // is not skipped next frame while nothing actually draws.
+            if (m_globalOrderBuffer == null)
+            {
+                GlobalRenderEnabled = false;
+                cmd.EndSample(k_samplerMerge.name);
+                return;
+            }
+            UpdateRendererTransforms();
+            DispatchMerge(cmd);
+            cmd.EndSample(k_samplerMerge.name);
         }
 
+        // -----------------------------------------------------------------------
+        // Global buffer management
+        // -----------------------------------------------------------------------
+        void EnsureGlobalBuffers(CommandBuffer cmd)
+        {
+            if (!m_globalBuffersDirty) return;
+            m_globalBuffersDirty = false;
+
+            DisposeGlobalBuffers();
+
+            m_totalSplatCount = 0;
+            m_rendererOffsets = new uint[m_activeGsplats.Count];
+            m_globalSHBands   = m_activeGsplats.Count > 0 ? m_activeGsplats[0].SHBands : (byte)0;
+
+            foreach (var gs in m_activeGsplats)
+                if (gs.SHBands < m_globalSHBands) m_globalSHBands = gs.SHBands;
+
+            for (int k = 0; k < m_activeGsplats.Count; k++)
+            {
+                m_rendererOffsets[k] = m_totalSplatCount;
+                m_totalSplatCount   += m_activeGsplats[k].SplatCount;
+            }
+
+            if (m_totalSplatCount == 0) return;
+
+            // Guard: renderer_id is packed into 8 bits ([31:24]); max 255 renderers.
+            if (m_activeGsplats.Count > 255)
+            {
+                Debug.LogError("[GsplatSorter] Global merge supports at most 255 renderers. Falling back to per-renderer rendering.");
+                m_globalBuffersDirty = true;
+                return;
+            }
+
+            // Guard: global merge only supports SPARK-compressed assets.
+            foreach (var gs in m_activeGsplats)
+            {
+                if (gs.PackedSplatsBuffer == null)
+                {
+                    var obj = gs as UnityEngine.Object;
+                    int id  = obj ? obj.GetInstanceID() : 0;
+                    if (m_warnedUncompressed.Add(id))
+                        Debug.LogWarning($"[GsplatSorter] '{obj?.name}' uses an uncompressed asset; global sort requires SPARK compression. Falling back to per-renderer rendering for this renderer.");
+                    m_globalBuffersDirty = true;
+                    return;
+                }
+            }
+
+            var st = GraphicsBuffer.Target.Structured;
+            m_globalPackedBuffer       = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4) { name = "Gsplat.GlobalPacked" };
+            m_globalOrderBuffer        = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))     { name = "Gsplat.GlobalOrder" };
+            m_rendererOffsetsBuffer    = new GraphicsBuffer(st, m_activeGsplats.Count,  sizeof(uint))     { name = "Gsplat.RendererOffsets" };
+            m_rendererTransformsBuffer = new GraphicsBuffer(st, m_activeGsplats.Count,  sizeof(float)*16) { name = "Gsplat.RendererTransforms" };
+
+            if (m_globalSHBands >= 1)
+                m_globalSH1Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 2) { name = "Gsplat.GlobalSH1" };
+            if (m_globalSHBands >= 2)
+                m_globalSH2Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4) { name = "Gsplat.GlobalSH2" };
+            if (m_globalSHBands >= 3)
+                m_globalSH3Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4) { name = "Gsplat.GlobalSH3" };
+            if (m_globalSHBands >= 4)
+                m_globalSH4Buffer = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint) * 4) { name = "Gsplat.GlobalSH4" };
+
+            m_rendererOffsetsBuffer.SetData(m_rendererOffsets);
+
+            // Copy per-renderer packed splat data into global buffer sub-ranges.
+            for (int k = 0; k < m_activeGsplats.Count; k++)
+            {
+                var gs     = m_activeGsplats[k];
+                uint count = gs.SplatCount;
+                uint off   = m_rendererOffsets[k];
+                if (count == 0) continue;
+
+                CopyUint4(cmd, gs.PackedSplatsBuffer, m_globalPackedBuffer, count, off);
+                if (m_globalSHBands >= 1 && gs.SH1Buffer != null)
+                    CopyUint2(cmd, gs.SH1Buffer, m_globalSH1Buffer, count, off);
+                if (m_globalSHBands >= 2 && gs.SH2Buffer != null)
+                    CopyUint4(cmd, gs.SH2Buffer, m_globalSH2Buffer, count, off);
+                if (m_globalSHBands >= 3 && gs.SH3Buffer != null)
+                    CopyUint4(cmd, gs.SH3Buffer, m_globalSH3Buffer, count, off);
+                if (m_globalSHBands >= 4 && gs.SH4Buffer != null)
+                    CopyUint4(cmd, gs.SH4Buffer, m_globalSH4Buffer, count, off);
+            }
+
+            // Allocate merge scratch buffers (always fresh after a dirty rebuild).
+            m_packScratchOrders  = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))  { name = "Gsplat.PackScratchOrders" };
+            m_packScratchDepths  = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(float)) { name = "Gsplat.PackScratchDepths" };
+            m_mergeScratchOrders = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(uint))  { name = "Gsplat.MergeScratchOrders" };
+            m_mergeScratchDepths = new GraphicsBuffer(st, (int)m_totalSplatCount, sizeof(float)) { name = "Gsplat.MergeScratchDepths" };
+            m_scratchCapacity    = m_totalSplatCount;
+        }
+
+        void UpdateRendererTransforms()
+        {
+            if (m_rendererTransformsBuffer == null) return;
+            int count = m_activeGsplats.Count;
+            if (m_rendererTransformsCache == null || m_rendererTransformsCache.Length != count)
+                m_rendererTransformsCache = new Matrix4x4[count];
+            for (int k = 0; k < count; k++)
+                m_rendererTransformsCache[k] = m_activeGsplats[k].transform.localToWorldMatrix;
+            m_rendererTransformsBuffer.SetData(m_rendererTransformsCache);
+        }
+
+        // -----------------------------------------------------------------------
+        // Copy helpers (GPU-side via command buffer)
+        // -----------------------------------------------------------------------
+        void CopyUint4(CommandBuffer cmd, GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
+        {
+            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_srcElementCount,  (int)count);
+            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_dstElementOffset, (int)dstOff);
+            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, k_srcUint4, src);
+            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, k_dstUint4, dst);
+            cmd.DispatchCompute(m_globalMaterial.CopyBufferShader, m_kernelCopyUint4, (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
+        }
+
+        void CopyUint2(CommandBuffer cmd, GraphicsBuffer src, GraphicsBuffer dst, uint count, uint dstOff)
+        {
+            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_srcElementCount,  (int)count);
+            cmd.SetComputeIntParam(m_globalMaterial.CopyBufferShader, k_dstElementOffset, (int)dstOff);
+            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, k_srcUint2, src);
+            cmd.SetComputeBufferParam(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, k_dstUint2, dst);
+            cmd.DispatchCompute(m_globalMaterial.CopyBufferShader, m_kernelCopyUint2, (int)GsplatUtils.DivRoundUp(count, 256), 1, 1);
+        }
+
+        // -----------------------------------------------------------------------
+        // Merge dispatch
+        // -----------------------------------------------------------------------
+        void DispatchMerge(CommandBuffer cmd)
+        {
+            int K = m_activeGsplats.Count;
+            if (K < 2 || m_globalOrderBuffer == null) return;
+
+            // Step 1: pack each renderer's sorted orders + depths into m_packScratch.
+            for (int k = 0; k < K; k++)
+            {
+                var gs    = m_activeGsplats[k];
+                if (gs.SorterResource is not Resource res) continue;
+                uint cnt  = gs.RemainingCount;
+                uint off  = m_rendererOffsets[k];
+                if (cnt == 0) continue;
+
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_rendererIdx, k);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_srcCount,    (int)cnt);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_dstOffset,   (int)off);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_rawOrders,    res.OrderBuffer);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_rawDepths,    res.InputKeys);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_packedOrders, m_packScratchOrders);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, m_kernelPackOrders, k_packedDepths, m_packScratchDepths);
+                cmd.DispatchCompute(m_globalMaterial.MergeShader, m_kernelPackOrders, (int)GsplatUtils.DivRoundUp(cnt, 256), 1, 1);
+            }
+
+            // Step 2: cascaded 2-way merges.
+            // After each pass the merged sub-range grows. We alternate writing between
+            // m_packScratch (treated as read-only source) and m_mergeScratch.
+            // Source for renderer k's sorted range is always m_packScratchOrders[off[k]..off[k]+cnt[k]).
+            // The merged-so-far result alternates between m_mergeScratch and a temporary swap.
+
+            uint mergedCount  = m_activeGsplats[0].RemainingCount;   // size of merged result so far
+            uint mergedOffset = 0;                                    // always at start of its scratch buffer
+
+            // Current merged result lives in: packScratch initially (range [0, mergedCount)).
+            // We swap between packScratch and mergeScratch each pass.
+            bool mergedInPack = true;
+
+            for (int k = 1; k < K; k++)
+            {
+                var gs      = m_activeGsplats[k];
+                uint cntK   = gs.RemainingCount;
+                uint offK   = m_rendererOffsets[k];
+                bool isFinal = (k == K - 1);
+                uint total  = mergedCount + cntK;
+
+                // Source A: current merged result.
+                var srcAOrders = mergedInPack ? m_packScratchOrders : m_mergeScratchOrders;
+                var srcADepths = mergedInPack ? m_packScratchDepths : m_mergeScratchDepths;
+
+                // Source B: renderer k's range in packScratch.
+                // (always in packScratch regardless of which buffer holds merged result)
+                var srcBOrders = m_packScratchOrders;
+                var srcBDepths = m_packScratchDepths;
+
+                // Destination: final pass → globalOrderBuffer; otherwise the other scratch.
+                GraphicsBuffer dstOrders, dstDepths;
+                if (isFinal)
+                {
+                    dstOrders = m_globalOrderBuffer;
+                    dstDepths = null;
+                }
+                else
+                {
+                    dstOrders = mergedInPack ? m_mergeScratchOrders : m_packScratchOrders;
+                    dstDepths = mergedInPack ? m_mergeScratchDepths : m_packScratchDepths;
+                }
+
+                int kernel = isFinal ? m_kernelMergeTwo : m_kernelMergeTwoWithDepth;
+
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_offsetA,      (int)mergedOffset);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_offsetB,      (int)offK);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_countA,       (int)mergedCount);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_countB,       (int)cntK);
+                cmd.SetComputeIntParam(m_globalMaterial.MergeShader, k_outputOffset,  0);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_depthsA,      srcADepths);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_ordersA,      srcAOrders);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_depthsB,      srcBDepths);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_ordersB,      srcBOrders);
+                cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_outputOrders, dstOrders);
+                if (!isFinal)
+                    cmd.SetComputeBufferParam(m_globalMaterial.MergeShader, kernel, k_outputDepths, dstDepths);
+
+                cmd.DispatchCompute(m_globalMaterial.MergeShader, kernel, (int)GsplatUtils.DivRoundUp(total, 256), 1, 1);
+
+                mergedCount  = total;
+                mergedOffset = 0;           // output always starts at 0 in the destination buffer
+                mergedInPack = !mergedInPack;
+            }
+
+            m_totalRemainingCount = mergedCount;
+        }
+
+        // -----------------------------------------------------------------------
+        // Global draw call
+        // -----------------------------------------------------------------------
+        public void DrawAllIfEnabled(CommandBuffer cmd, Camera camera)
+        {
+            if (GlobalRenderEnabled)
+                DrawAll(cmd, camera);
+        }
+
+        void DrawAll(CommandBuffer cmd, Camera camera)
+        {
+            if (m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
+
+            cmd?.BeginSample(k_samplerDraw.name);
+
+            var mat = m_globalMaterial.Materials[m_globalSHBands];
+            mat.SetBuffer(k_globalOrderBuffer,      m_globalOrderBuffer);
+            mat.SetBuffer(k_globalPackedBuffer,     m_globalPackedBuffer);
+            mat.SetBuffer(k_rendererOffsetsProp,    m_rendererOffsetsBuffer);
+            mat.SetBuffer(k_rendererTransformsProp, m_rendererTransformsBuffer);
+            mat.SetInt(k_totalSplatCount,           (int)m_totalRemainingCount);
+            mat.SetInt(k_splatInstanceSize,         (int)GsplatSettings.Instance.SplatInstanceSize);
+
+            if (m_globalSH1Buffer != null)
+                mat.SetBuffer(k_globalSH1Buffer, m_globalSH1Buffer);
+            if (m_globalSH2Buffer != null)
+                mat.SetBuffer(k_globalSH2Buffer, m_globalSH2Buffer);
+            if (m_globalSH3Buffer != null)
+                mat.SetBuffer(k_globalSH3Buffer, m_globalSH3Buffer);
+            if (m_globalSH4Buffer != null)
+                mat.SetBuffer(k_globalSH4Buffer, m_globalSH4Buffer);
+
+            // Use the first renderer's visual settings as representative.
+            var rep = m_activeGsplats[0] as GsplatRenderer;
+            if (rep != null)
+            {
+                mat.SetFloat(k_brightness,  rep.Brightness);
+                mat.SetFloat(k_scaleFactor, 1.0f - rep.SplatDownscaleFactor);
+                mat.SetInt(k_gammaToLinear, rep.GammaToLinear ? 1 : 0);
+                mat.SetInt(k_shDegree,      Mathf.Min(rep.SHDegree, m_globalSHBands));
+            }
+
+            var rp = new RenderParams(mat)
+            {
+                worldBounds = new Bounds(Vector3.zero, Vector3.one * 1e6f),
+                camera      = camera
+            };
+
+            int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            Graphics.RenderMeshPrimitives(rp, GsplatSettings.Instance.Mesh, 0, instances);
+
+            cmd?.EndSample(k_samplerDraw.name);
+        }
+
+        // -----------------------------------------------------------------------
+        // Cleanup
+        // -----------------------------------------------------------------------
+        void DisposeGlobalBuffers()
+        {
+            m_globalPackedBuffer?.Dispose();        m_globalPackedBuffer       = null;
+            m_globalSH1Buffer?.Dispose();           m_globalSH1Buffer          = null;
+            m_globalSH2Buffer?.Dispose();           m_globalSH2Buffer          = null;
+            m_globalSH3Buffer?.Dispose();           m_globalSH3Buffer          = null;
+            m_globalSH4Buffer?.Dispose();           m_globalSH4Buffer          = null;
+            m_globalOrderBuffer?.Dispose();         m_globalOrderBuffer        = null;
+            m_rendererOffsetsBuffer?.Dispose();     m_rendererOffsetsBuffer    = null;
+            m_rendererTransformsBuffer?.Dispose();  m_rendererTransformsBuffer = null;
+            // Scratch buffers are rebuilt every time global buffers are rebuilt,
+            // so dispose them here too to avoid leaking when renderer count shrinks.
+            m_packScratchOrders?.Dispose();         m_packScratchOrders        = null;
+            m_packScratchDepths?.Dispose();         m_packScratchDepths        = null;
+            m_mergeScratchOrders?.Dispose();        m_mergeScratchOrders       = null;
+            m_mergeScratchDepths?.Dispose();        m_mergeScratchDepths       = null;
+            m_scratchCapacity = 0;
+        }
+
+        // -----------------------------------------------------------------------
+        // Public API
+        // -----------------------------------------------------------------------
         public ISorterResource CreateSorterResource(uint count, GraphicsBuffer orderBuffer)
         {
             return new Resource(count, orderBuffer);
         }
+
+        /// <summary>
+        /// Call when a renderer's asset changes so the global packed buffer is rebuilt next frame.
+        /// </summary>
+        public void MarkGlobalBuffersDirty() => m_globalBuffersDirty = true;
     }
 }

--- a/Runtime/GsplatUtils.cs
+++ b/Runtime/GsplatUtils.cs
@@ -10,7 +10,7 @@ namespace Gsplat
     public static class GsplatUtils
     {
         public const string k_PackagePath = "Packages/wu.yize.gsplat/";
-        public static readonly Version k_Version = new("1.2.1");
+        public static readonly Version k_Version = new("1.3.0");
 
         // radix sort etc. friendly, see http://stereopsis.com/radix.html
         public static uint FloatToSortableUint(float f)

--- a/Runtime/GsplatUtils.cs
+++ b/Runtime/GsplatUtils.cs
@@ -10,7 +10,7 @@ namespace Gsplat
     public static class GsplatUtils
     {
         public const string k_PackagePath = "Packages/wu.yize.gsplat/";
-        public static readonly Version k_Version = new("1.3.0");
+        public static readonly Version k_Version = new("1.4.0");
 
         // radix sort etc. friendly, see http://stereopsis.com/radix.html
         public static uint FloatToSortableUint(float f)

--- a/Runtime/Materials/GsplatGlobal.asset
+++ b/Runtime/Materials/GsplatGlobal.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6, type: 3}
+  m_Name: GsplatGlobal
+  m_EditorClassIdentifier:
+  DefaultMaterial: {fileID: 2100000, guid: e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8, type: 2}
+  MergeShader: {fileID: 7200000, guid: a1e5c8f2b4d7903e6f2a8c1d5e9b3f70, type: 3}
+  CopyBufferShader: {fileID: 7200000, guid: 3f7a1c4e8b2d9f506e1a4c7d3b8f2e90, type: 3}

--- a/Runtime/Materials/GsplatGlobal.asset.meta
+++ b/Runtime/Materials/GsplatGlobal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Materials/GsplatGlobal.mat
+++ b/Runtime/Materials/GsplatGlobal.mat
@@ -17,7 +17,7 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3000
+  m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
   m_LockedProperties: 

--- a/Runtime/Materials/GsplatGlobal.mat
+++ b/Runtime/Materials/GsplatGlobal.mat
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GsplatGlobal
+  m_Shader: {fileID: 4800000, guid: c2f8e5a9b3d1604f7e3c9a6b2f4d8e1c, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - SH_BANDS_3
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats:
+    - _Brightness: 1
+    - _GammaToLinear: 1
+    - _ScaleFactor: 1
+    m_Colors: []
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Runtime/Materials/GsplatGlobal.mat.meta
+++ b/Runtime/Materials/GsplatGlobal.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SRP/GsplatURPFeature.cs
+++ b/Runtime/SRP/GsplatURPFeature.cs
@@ -57,7 +57,6 @@ namespace Gsplat
         public override void OnCameraPreCull(ScriptableRenderer renderer, in CameraData cameraData)
         {
             m_hasGsplats = GsplatSorter.Instance.GatherGsplatsForCamera(cameraData.camera);
-            GsplatSorter.Instance.DrawAllIfEnabled(null, cameraData.camera);
 #if !UNITY_6000_0_OR_NEWER
             m_pass.CommandBuffer ??= new CommandBuffer { name = "SortGsplats" };
             m_pass.CommandBuffer.Clear();

--- a/Runtime/SRP/GsplatURPFeature.cs
+++ b/Runtime/SRP/GsplatURPFeature.cs
@@ -57,6 +57,7 @@ namespace Gsplat
         public override void OnCameraPreCull(ScriptableRenderer renderer, in CameraData cameraData)
         {
             m_hasGsplats = GsplatSorter.Instance.GatherGsplatsForCamera(cameraData.camera);
+            GsplatSorter.Instance.DrawAllIfEnabled(null, cameraData.camera);
 #if !UNITY_6000_0_OR_NEWER
             m_pass.CommandBuffer ??= new CommandBuffer { name = "SortGsplats" };
             m_pass.CommandBuffer.Clear();

--- a/Runtime/Shaders/GsplatCopyBuffer.compute
+++ b/Runtime/Shaders/GsplatCopyBuffer.compute
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Keir Rice
+// SPDX-License-Identifier: MIT
+
+// Copies a sub-range of a structured buffer into a destination buffer at a given offset.
+// Used to sub-allocate per-renderer splat data into the global packed buffer.
+
+#define GROUP_SIZE 256
+
+#pragma kernel CopyUint4
+#pragma kernel CopyUint2
+
+// --- uint4 copy (PackedSplatsBuffer, SH2Buffer, SH3Buffer) ---
+StructuredBuffer<uint4>   _SrcUint4;
+RWStructuredBuffer<uint4> _DstUint4;
+uint _SrcElementCount;
+uint _DstElementOffset; // destination start index in elements
+
+[numthreads(GROUP_SIZE, 1, 1)]
+void CopyUint4(uint3 id : SV_DispatchThreadID)
+{
+    uint i = id.x;
+    if (i >= _SrcElementCount) return;
+    _DstUint4[_DstElementOffset + i] = _SrcUint4[i];
+}
+
+// --- uint2 copy (SH1Buffer: 2 uints per splat) ---
+StructuredBuffer<uint2>   _SrcUint2;
+RWStructuredBuffer<uint2> _DstUint2;
+// Reuses _SrcElementCount and _DstElementOffset
+
+[numthreads(GROUP_SIZE, 1, 1)]
+void CopyUint2(uint3 id : SV_DispatchThreadID)
+{
+    uint i = id.x;
+    if (i >= _SrcElementCount) return;
+    _DstUint2[_DstElementOffset + i] = _SrcUint2[i];
+}

--- a/Runtime/Shaders/GsplatCopyBuffer.compute.meta
+++ b/Runtime/Shaders/GsplatCopyBuffer.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3f7a1c4e8b2d9f506e1a4c7d3b8f2e90
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shaders/GsplatGlobal.shader
+++ b/Runtime/Shaders/GsplatGlobal.shader
@@ -31,11 +31,7 @@ Shader "Gsplat/Global"
 
             #include "UnityCG.cginc"
 
-            bool _GammaToLinear;
             int _SplatInstanceSize;
-            int _SHDegree;
-            float _Brightness;
-            float _ScaleFactor;
 
             #include "GsplatSparkGlobal.hlsl"
 
@@ -51,6 +47,7 @@ Shader "Gsplat/Global"
             struct v2f
             {
                 float2 uv : TEXCOORD0;
+                nointerpolation uint rendererId : TEXCOORD1;
                 float4 vertex : SV_POSITION;
                 float4 color : COLOR;
                 UNITY_VERTEX_OUTPUT_STEREO
@@ -71,7 +68,7 @@ Shader "Gsplat/Global"
                 #endif
 
                 GlobalSplatSource source;
-                if (!InitGlobalSource(instanceId, v.vertex.xyz, _ScaleFactor, source))
+                if (!InitGlobalSource(instanceId, v.vertex.xyz, source))
                     return o;
 
                 SplatCenter center;
@@ -85,7 +82,7 @@ Shader "Gsplat/Global"
                 float3 dir = normalize(mul(center.view, (float3x3)center.modelView));
                 float3 sh[SH_COEFFS];
                 InitGlobalSH(source, sh);
-                color.rgb += EvalSH(sh, dir, _SHDegree);
+                color.rgb += EvalSH(sh, dir, (int)_RendererParams[source.rendererId].shDegree);
                 #endif
 
                 ClipCorner(corner, color.a);
@@ -93,24 +90,27 @@ Shader "Gsplat/Global"
                 o.vertex = center.proj + float4(corner.offset.x, _ProjectionParams.x * corner.offset.y, 0, 0);
                 o.color  = color;
                 o.uv     = corner.uv;
+                o.rendererId = source.rendererId;
                 return o;
             }
 
             float4 frag(v2f i) : SV_Target
             {
+                RendererParams p = _RendererParams[i.rendererId];
+
                 float A = dot(i.uv, i.uv);
                 if (A > 1.0) discard;
 
                 float2 absUV = abs(i.uv);
                 float maxUV = max(absUV.x, absUV.y);
 
-                float falloff = -exp((maxUV - _ScaleFactor * 1.16) * 25 * _ScaleFactor);
+                float falloff = -exp((maxUV - p.scaleFactor * 1.16) * 25 * p.scaleFactor);
                 float alpha = (exp(-A * 4.0) + falloff) * i.color.a;
 
                 if (alpha < 1.0 / 255.0) discard;
-                if (_GammaToLinear)
-                    return float4(GammaToLinearSpace(i.color.rgb) * alpha * _Brightness, alpha);
-                return float4(i.color.rgb * alpha * _Brightness, alpha);
+                if (p.gammaToLinear)
+                    return float4(GammaToLinearSpace(i.color.rgb) * alpha * p.brightness, alpha);
+                return float4(i.color.rgb * alpha * p.brightness, alpha);
             }
             ENDHLSL
         }

--- a/Runtime/Shaders/GsplatGlobal.shader
+++ b/Runtime/Shaders/GsplatGlobal.shader
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Keir Rice
+// SPDX-License-Identifier: MIT
+//
+// Unified draw shader for global K-way merged Gaussian splatting.
+// Reads from concatenated global buffers (GlobalPackedBuffer, GlobalSH*Buffers)
+// via indices from GlobalOrderBuffer. Per-renderer transforms applied via
+// RendererTransforms structured buffer.
+
+Shader "Gsplat/Global"
+{
+    Properties {}
+    SubShader
+    {
+        Tags
+        {
+            "RenderType"="Transparent"
+            "Queue"="Transparent"
+        }
+
+        Pass
+        {
+            ZWrite Off
+            Blend One OneMinusSrcAlpha
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma require compute
+            #pragma multi_compile SH_BANDS_0 SH_BANDS_1 SH_BANDS_2 SH_BANDS_3 SH_BANDS_4
+
+            #include "UnityCG.cginc"
+
+            bool _GammaToLinear;
+            int _SplatInstanceSize;
+            int _SHDegree;
+            float _Brightness;
+            float _ScaleFactor;
+
+            #include "GsplatSparkGlobal.hlsl"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                #if !defined(UNITY_INSTANCING_ENABLED) && !defined(UNITY_PROCEDURAL_INSTANCING_ENABLED) && !defined(UNITY_STEREO_INSTANCING_ENABLED)
+                uint instanceID : SV_InstanceID;
+                #endif
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+                float4 color : COLOR;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = discardVec;
+
+                #if !defined(UNITY_INSTANCING_ENABLED) && !defined(UNITY_PROCEDURAL_INSTANCING_ENABLED) && !defined(UNITY_STEREO_INSTANCING_ENABLED)
+                uint instanceId = v.instanceID;
+                #else
+                uint instanceId = unity_InstanceID;
+                #endif
+
+                GlobalSplatSource source;
+                if (!InitGlobalSource(instanceId, v.vertex.xyz, _ScaleFactor, source))
+                    return o;
+
+                SplatCenter center;
+                SplatCorner corner;
+                float4 color;
+                if (!InitGlobalSplatData(source, center, corner, color))
+                    return o;
+
+                #ifndef SH_BANDS_0
+                // center.modelView is already computed by InitGlobalSplatData → InitCenter.
+                float3 dir = normalize(mul(center.view, (float3x3)center.modelView));
+                float3 sh[SH_COEFFS];
+                InitGlobalSH(source, sh);
+                color.rgb += EvalSH(sh, dir, _SHDegree);
+                #endif
+
+                ClipCorner(corner, color.a);
+
+                o.vertex = center.proj + float4(corner.offset.x, _ProjectionParams.x * corner.offset.y, 0, 0);
+                o.color  = color;
+                o.uv     = corner.uv;
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float A = dot(i.uv, i.uv);
+                if (A > 1.0) discard;
+
+                float2 absUV = abs(i.uv);
+                float maxUV = max(absUV.x, absUV.y);
+
+                float falloff = -exp((maxUV - _ScaleFactor * 1.16) * 25 * _ScaleFactor);
+                float alpha = (exp(-A * 4.0) + falloff) * i.color.a;
+
+                if (alpha < 1.0 / 255.0) discard;
+                if (_GammaToLinear)
+                    return float4(GammaToLinearSpace(i.color.rgb) * alpha * _Brightness, alpha);
+                return float4(i.color.rgb * alpha * _Brightness, alpha);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Runtime/Shaders/GsplatGlobal.shader.meta
+++ b/Runtime/Shaders/GsplatGlobal.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c2f8e5a9b3d1604f7e3c9a6b2f4d8e1c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Shaders/GsplatMergeOrderBuffers.compute
+++ b/Runtime/Shaders/GsplatMergeOrderBuffers.compute
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Keir Rice
+// SPDX-License-Identifier: MIT
+//
+// K-way merge of per-renderer sorted depth/order buffers into a single GlobalOrderBuffer.
+//
+// Each entry in GlobalOrderBuffer is a packed uint:
+//   bits [31:24] = renderer_id  (0-255)
+//   bits [23: 0] = local_splat_id (filtered local index within that renderer's OrderBuffer)
+//
+// Workflow (dispatched by GsplatSorter):
+//   1. PackRendererOrders (one dispatch per renderer)
+//      Reads raw per-renderer OrderBuffer + InputKeys depths, writes packed orders + depths
+//      into a shared scratch buffer at the renderer's assigned offset.
+//   2. MergeTwoWithDepth (K-2 intermediate dispatches for K > 2)
+//      2-way parallel binary merge of two sorted sub-ranges → merged orders + depths.
+//      Result written to a ping-pong scratch buffer pair.
+//   3. MergeTwo (final dispatch)
+//      2-way parallel binary merge → GlobalOrderBuffer only (no depth output needed).
+//
+// All depth lists are sorted ascending (back-to-front: smallest depth = farthest splat).
+
+#define GROUP_SIZE 256
+#define FLOAT_MAX  3.402823466e+38f
+
+#pragma kernel PackRendererOrders
+#pragma kernel MergeTwo
+#pragma kernel MergeTwoWithDepth
+
+// -----------------------------------------------------------------------
+// PackRendererOrders
+// Packs one renderer's raw OrderBuffer and InputKeys into a shared scratch
+// buffer at the given offset, embedding the renderer ID into the high bits.
+// -----------------------------------------------------------------------
+StructuredBuffer<uint>    _RawOrders;     // per-renderer OrderBuffer (local splat IDs)
+StructuredBuffer<float>   _RawDepths;     // per-renderer InputKeys  (sorted depths)
+RWStructuredBuffer<uint>  _PackedOrders;  // scratch packed orders
+RWStructuredBuffer<float> _PackedDepths;  // scratch depths
+
+uint _RendererIdx;   // renderer ID to embed in bits [31:24]
+uint _SrcCount;      // number of valid elements to pack
+uint _DstOffset;     // element start index in the scratch buffers
+
+[numthreads(GROUP_SIZE, 1, 1)]
+void PackRendererOrders(uint3 id : SV_DispatchThreadID)
+{
+    uint i = id.x;
+    if (i >= _SrcCount) return;
+    _PackedOrders[_DstOffset + i] = (_RendererIdx << 24u) | (_RawOrders[i] & 0x00FFFFFFu);
+    _PackedDepths[_DstOffset + i] = _RawDepths[i];
+}
+
+// -----------------------------------------------------------------------
+// Shared merge parameters
+// Two sorted sub-ranges of the input buffers:
+//   A: [_OffsetA, _OffsetA + _CountA)
+//   B: [_OffsetB, _OffsetB + _CountB)
+// Output: [_OutputOffset, _OutputOffset + _CountA + _CountB)
+// -----------------------------------------------------------------------
+StructuredBuffer<float>   _DepthsA;
+StructuredBuffer<uint>    _OrdersA;       // packed (renderer_id:8 | local_splat_id:24)
+StructuredBuffer<float>   _DepthsB;
+StructuredBuffer<uint>    _OrdersB;
+
+uint _OffsetA;
+uint _OffsetB;
+uint _CountA;
+uint _CountB;
+uint _OutputOffset;
+
+RWStructuredBuffer<uint>  _OutputOrders;
+RWStructuredBuffer<float> _OutputDepths;  // written only by MergeTwoWithDepth
+
+// Binary search for the number of elements from A that precede merged output position p.
+// Both lists sorted ascending; we want the p-th smallest element overall.
+uint MergePathSplit(uint p)
+{
+    // Clamp to valid range of i (elements drawn from A).
+    uint lo = (p >= _CountB) ? p - _CountB : 0u;
+    uint hi = min(p, _CountA);
+
+    while (lo < hi)
+    {
+        uint mid  = lo + (hi - lo) / 2u;
+        float dA  = _DepthsA[_OffsetA + mid];
+        uint  jB  = p - mid - 1u;
+        float dB  = (jB < _CountB) ? _DepthsB[_OffsetB + jB] : -FLOAT_MAX;
+
+        // A[mid] <= B[p-mid-1] means mid can still precede position p: try larger i.
+        if (dA <= dB)
+            lo = mid + 1u;
+        else
+            hi = mid;
+    }
+
+    return lo;
+}
+
+// Final merge pass — writes to GlobalOrderBuffer only.
+[numthreads(GROUP_SIZE, 1, 1)]
+void MergeTwo(uint3 id : SV_DispatchThreadID)
+{
+    uint p     = id.x;
+    uint total = _CountA + _CountB;
+    if (p >= total) return;
+
+    uint i = MergePathSplit(p);
+    uint j = p - i;
+
+    float dA = (i < _CountA) ? _DepthsA[_OffsetA + i] : FLOAT_MAX;
+    float dB = (j < _CountB) ? _DepthsB[_OffsetB + j] : FLOAT_MAX;
+
+    _OutputOrders[_OutputOffset + p] = (dA <= dB) ? _OrdersA[_OffsetA + i] : _OrdersB[_OffsetB + j];
+}
+
+// Intermediate merge pass — writes merged orders AND depths to scratch.
+[numthreads(GROUP_SIZE, 1, 1)]
+void MergeTwoWithDepth(uint3 id : SV_DispatchThreadID)
+{
+    uint p     = id.x;
+    uint total = _CountA + _CountB;
+    if (p >= total) return;
+
+    uint i = MergePathSplit(p);
+    uint j = p - i;
+
+    float dA = (i < _CountA) ? _DepthsA[_OffsetA + i] : FLOAT_MAX;
+    float dB = (j < _CountB) ? _DepthsB[_OffsetB + j] : FLOAT_MAX;
+
+    if (dA <= dB)
+    {
+        _OutputOrders[_OutputOffset + p] = _OrdersA[_OffsetA + i];
+        _OutputDepths[_OutputOffset + p] = dA;
+    }
+    else
+    {
+        _OutputOrders[_OutputOffset + p] = _OrdersB[_OffsetB + j];
+        _OutputDepths[_OutputOffset + p] = dB;
+    }
+}

--- a/Runtime/Shaders/GsplatMergeOrderBuffers.compute.meta
+++ b/Runtime/Shaders/GsplatMergeOrderBuffers.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a1e5c8f2b4d7903e6f2a8c1d5e9b3f70
+ComputeShaderImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Shaders/GsplatSparkGlobal.hlsl
+++ b/Runtime/Shaders/GsplatSparkGlobal.hlsl
@@ -32,6 +32,16 @@ StructuredBuffer<uint4>    _GlobalSH4Buffer;
 StructuredBuffer<uint>     _RendererOffsets;    // splat start index in global buffers, per renderer
 StructuredBuffer<float4x4> _RendererTransforms; // localToWorldMatrix, per renderer
 
+// Per-renderer visual settings, looked up by renderer_id. Matches RendererParams in GsplatSorter.cs.
+struct RendererParams
+{
+    float brightness;
+    float scaleFactor;
+    uint  gammaToLinear;
+    uint  shDegree;
+};
+StructuredBuffer<RendererParams> _RendererParams;
+
 // Merged sorted index buffer (output of the merge pass).
 // Entry: (renderer_id:8 | local_splat_id:24)
 StructuredBuffer<uint>     _GlobalOrderBuffer;
@@ -47,7 +57,7 @@ struct GlobalSplatSource
     float2 cornerUV;
 };
 
-bool InitGlobalSource(uint instanceId, float3 vertex, float scaleFactor, out GlobalSplatSource source)
+bool InitGlobalSource(uint instanceId, float3 vertex, out GlobalSplatSource source)
 {
     source.order = instanceId * _SplatInstanceSize + asuint(vertex.z);
 
@@ -57,7 +67,7 @@ bool InitGlobalSource(uint instanceId, float3 vertex, float scaleFactor, out Glo
     uint packed     = _GlobalOrderBuffer[source.order];
     source.rendererId = packed >> 24u;
     source.id         = packed & 0x00FFFFFFu;
-    source.cornerUV   = float2(vertex.x, vertex.y) * scaleFactor;
+    source.cornerUV   = float2(vertex.x, vertex.y) * _RendererParams[source.rendererId].scaleFactor;
     return true;
 }
 

--- a/Runtime/Shaders/GsplatSparkGlobal.hlsl
+++ b/Runtime/Shaders/GsplatSparkGlobal.hlsl
@@ -1,0 +1,245 @@
+// Copyright (c) 2025 Yize Wu
+// Copyright (c) 2026 Keir Rice
+// SPDX-License-Identifier: MIT
+//
+// Global-merge variant of GsplatSpark.hlsl.
+// Reads splat data from concatenated global buffers instead of per-renderer buffers.
+// Each GlobalOrderBuffer entry packs (renderer_id:8 | local_splat_id:24).
+// Renderer transforms and global buffer offsets are provided via structured buffers.
+
+#ifndef GSPLAT_SPARK_GLOBAL_INCLUDED
+#define GSPLAT_SPARK_GLOBAL_INCLUDED
+
+#include "Gsplat.hlsl"
+#include "GsplatSpark.hlsl"
+
+// Global concatenated data buffers (sub-allocated by renderer at registration time).
+StructuredBuffer<uint4>    _GlobalPackedBuffer;
+#ifndef SH_BANDS_0
+StructuredBuffer<uint2>    _GlobalSH1Buffer;
+#if defined(SH_BANDS_2) || defined(SH_BANDS_3) || defined(SH_BANDS_4)
+StructuredBuffer<uint4>    _GlobalSH2Buffer;
+#endif
+#if defined(SH_BANDS_3) || defined(SH_BANDS_4)
+StructuredBuffer<uint4>    _GlobalSH3Buffer;
+#endif
+#ifdef SH_BANDS_4
+StructuredBuffer<uint4>    _GlobalSH4Buffer;
+#endif
+#endif
+
+// Per-renderer metadata (updated when renderers register/move).
+StructuredBuffer<uint>     _RendererOffsets;    // splat start index in global buffers, per renderer
+StructuredBuffer<float4x4> _RendererTransforms; // localToWorldMatrix, per renderer
+
+// Merged sorted index buffer (output of the merge pass).
+// Entry: (renderer_id:8 | local_splat_id:24)
+StructuredBuffer<uint>     _GlobalOrderBuffer;
+
+uint _TotalSplatCount;
+
+// Extended source struct for global rendering.
+struct GlobalSplatSource
+{
+    uint order;
+    uint rendererId;
+    uint id;          // local splat ID within the renderer
+    float2 cornerUV;
+};
+
+bool InitGlobalSource(uint instanceId, float3 vertex, float scaleFactor, out GlobalSplatSource source)
+{
+    source.order = instanceId * _SplatInstanceSize + asuint(vertex.z);
+
+    if (source.order >= _TotalSplatCount)
+        return false;
+
+    uint packed     = _GlobalOrderBuffer[source.order];
+    source.rendererId = packed >> 24u;
+    source.id         = packed & 0x00FFFFFFu;
+    source.cornerUV   = float2(vertex.x, vertex.y) * scaleFactor;
+    return true;
+}
+
+bool InitGlobalSplatData(GlobalSplatSource source, out SplatCenter center, out SplatCorner corner,
+                         out float4 color)
+{
+    center = (SplatCenter)0;
+    corner = (SplatCorner)0;
+    color  = float4(0, 0, 0, 0);
+
+    uint globalIdx = _RendererOffsets[source.rendererId] + source.id;
+    uint4 packedSplat = _GlobalPackedBuffer[globalIdx];
+
+    float3 modelCenter, scale;
+    float4 quat;
+    UnpackSplat(packedSplat, color, modelCenter, scale, quat);
+
+    float4x4 rendererTransform = _RendererTransforms[source.rendererId];
+    float4x4 modelView = mul(UNITY_MATRIX_V, rendererTransform);
+
+    if (!InitCenter(modelView, modelCenter, center))
+        return false;
+
+    // Re-use SplatSource.cornerUV via a temporary SplatSource for InitCorner.
+    SplatSource tmp;
+    tmp.order     = source.order;
+    tmp.id        = source.id;
+    tmp.cornerUV  = source.cornerUV;
+
+    SplatCovariance cov = CalcCovariance(quat, scale);
+    if (!InitCorner(tmp, cov, center, corner))
+        return false;
+
+    return true;
+}
+
+#ifndef SH_BANDS_0
+void InitGlobalSH(GlobalSplatSource source, out float3 sh[SH_COEFFS])
+{
+    uint globalIdx = _RendererOffsets[source.rendererId] + source.id;
+
+    uint2 packedSH1 = _GlobalSH1Buffer[globalIdx];
+    #if defined(SH_BANDS_2) || defined(SH_BANDS_3) || defined(SH_BANDS_4)
+    uint4 packedSH2 = _GlobalSH2Buffer[globalIdx];
+    #endif
+    #if defined(SH_BANDS_3) || defined(SH_BANDS_4)
+    uint4 packedSH3 = _GlobalSH3Buffer[globalIdx];
+    #endif
+    #ifdef SH_BANDS_4
+    uint4 packedSH4 = _GlobalSH4Buffer[globalIdx];
+    #endif
+
+    // Decode identically to GsplatSpark.hlsl InitSH.
+    sh[0] = float3(
+        int(packedSH1.x << 25u) >> 25,
+        int(packedSH1.x << 18u) >> 25,
+        int(packedSH1.x << 11u) >> 25
+    ) / 63.0;
+    sh[1] = float3(
+        int(packedSH1.x << 4u) >> 25,
+        int((packedSH1.x >> 3u) | (packedSH1.y << 29u)) >> 25,
+        int(packedSH1.y << 22u) >> 25
+    ) / 63.0;
+    sh[2] = float3(
+        int(packedSH1.y << 15u) >> 25,
+        int(packedSH1.y << 8u) >> 25,
+        int(packedSH1.y << 1u) >> 25
+    ) / 63.0;
+    #if defined(SH_BANDS_2) || defined(SH_BANDS_3) || defined(SH_BANDS_4)
+    sh[3] = float3(
+        int(packedSH2.x << 24u) >> 24,
+        int(packedSH2.x << 16u) >> 24,
+        int(packedSH2.x << 8u)  >> 24
+    ) / 127.0;
+    sh[4] = float3(
+        int(packedSH2.x) >> 24,
+        int(packedSH2.y << 24u) >> 24,
+        int(packedSH2.y << 16u) >> 24
+    ) / 127.0;
+    sh[5] = float3(
+        int(packedSH2.y << 8u) >> 24,
+        int(packedSH2.y) >> 24,
+        int(packedSH2.z << 24u) >> 24
+    ) / 127.0;
+    sh[6] = float3(
+        int(packedSH2.z << 16u) >> 24,
+        int(packedSH2.z << 8u)  >> 24,
+        int(packedSH2.z) >> 24
+    ) / 127.0;
+    sh[7] = float3(
+        int(packedSH2.w << 24u) >> 24,
+        int(packedSH2.w << 16u) >> 24,
+        int(packedSH2.w << 8u)  >> 24
+    ) / 127.0;
+    #endif
+    #if defined(SH_BANDS_3) || defined(SH_BANDS_4)
+    sh[8] = float3(
+        int(packedSH3.x << 26u) >> 26,
+        int(packedSH3.x << 20u) >> 26,
+        int(packedSH3.x << 14u) >> 26
+    ) / 31.0;
+    sh[9] = float3(
+        int(packedSH3.x << 8u) >> 26,
+        int(packedSH3.x << 2u) >> 26,
+        int((packedSH3.x >> 4u) | (packedSH3.y << 28u)) >> 26
+    ) / 31.0;
+    sh[10] = float3(
+        int(packedSH3.y << 22u) >> 26,
+        int(packedSH3.y << 16u) >> 26,
+        int(packedSH3.y << 10u) >> 26
+    ) / 31.0;
+    sh[11] = float3(
+        int(packedSH3.y << 4u) >> 26,
+        int((packedSH3.y >> 2u) | (packedSH3.z << 30u)) >> 26,
+        int(packedSH3.z << 24u) >> 26
+    ) / 31.0;
+    sh[12] = float3(
+        int(packedSH3.z << 18u) >> 26,
+        int(packedSH3.z << 12u) >> 26,
+        int(packedSH3.z << 6u)  >> 26
+    ) / 31.0;
+    sh[13] = float3(
+        int(packedSH3.z) >> 26,
+        int(packedSH3.w << 26u) >> 26,
+        int(packedSH3.w << 20u) >> 26
+    ) / 31.0;
+    sh[14] = float3(
+        int(packedSH3.w << 14u) >> 26,
+        int(packedSH3.w << 8u)  >> 26,
+        int(packedSH3.w << 2u)  >> 26
+    ) / 31.0;
+    #endif
+    #ifdef SH_BANDS_4
+    // Extract sint4 values packed into 4 x uint32 (8 values per word; 5 unused tail slots).
+    // value i (i in [0..26]) lives in word i/8 at bit offset (i%8)*4.
+    sh[15] = float3(
+        int(packedSH4.x << 28u) >> 28,
+        int(packedSH4.x << 24u) >> 28,
+        int(packedSH4.x << 20u) >> 28
+    ) / 7.0;
+    sh[16] = float3(
+        int(packedSH4.x << 16u) >> 28,
+        int(packedSH4.x << 12u) >> 28,
+        int(packedSH4.x << 8u)  >> 28
+    ) / 7.0;
+    sh[17] = float3(
+        int(packedSH4.x << 4u) >> 28,
+        int(packedSH4.x) >> 28,
+        int(packedSH4.y << 28u) >> 28
+    ) / 7.0;
+    sh[18] = float3(
+        int(packedSH4.y << 24u) >> 28,
+        int(packedSH4.y << 20u) >> 28,
+        int(packedSH4.y << 16u) >> 28
+    ) / 7.0;
+    sh[19] = float3(
+        int(packedSH4.y << 12u) >> 28,
+        int(packedSH4.y << 8u)  >> 28,
+        int(packedSH4.y << 4u)  >> 28
+    ) / 7.0;
+    sh[20] = float3(
+        int(packedSH4.y) >> 28,
+        int(packedSH4.z << 28u) >> 28,
+        int(packedSH4.z << 24u) >> 28
+    ) / 7.0;
+    sh[21] = float3(
+        int(packedSH4.z << 20u) >> 28,
+        int(packedSH4.z << 16u) >> 28,
+        int(packedSH4.z << 12u) >> 28
+    ) / 7.0;
+    sh[22] = float3(
+        int(packedSH4.z << 8u) >> 28,
+        int(packedSH4.z << 4u) >> 28,
+        int(packedSH4.z) >> 28
+    ) / 7.0;
+    sh[23] = float3(
+        int(packedSH4.w << 28u) >> 28,
+        int(packedSH4.w << 24u) >> 28,
+        int(packedSH4.w << 20u) >> 28
+    ) / 7.0;
+    #endif
+}
+#endif // !SH_BANDS_0
+
+#endif // GSPLAT_SPARK_GLOBAL_INCLUDED

--- a/Runtime/Shaders/GsplatSparkGlobal.hlsl.meta
+++ b/Runtime/Shaders/GsplatSparkGlobal.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9d4b7f1a3c6e80250b8f4a2d7c1e5b93
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
### What and why
Having multiple splats in the scene works, but I often run into issues with the sorting order. Objects that should be behind render in front, and vice versa, especially where two splat objects overlap. Global sort fixes this.

Per-renderer sorting still produces correct depth ordering within each splat object. What's missing is the ability to interleave gaussians across renderers. This PR adds an optional GPU K-way merge that collapses all per-renderer sorted order buffers into a single globally depth-sorted draw call. All local transforms still get applied just like normal. All the SH lookups are correct. The render looks identical to the default code paths. The package falls back to the existing per-renderer pipeline when:
 - When disabled
 - When only one renderer is active
 - When any active renderer is uncompressed

### Approach
Per-frame data flow:
1. **Per-renderer depth** - unchanged.
2. **Per-renderer radix sort** - unchanged. Each renderer's local `OrderBuffer` is sorted by depth.
3. **K-way merge** (new, entirely GPU-side) - cascaded 2-way merges along the merge-path algorithm. `Renderer ID` is packed into the high 8 bits of the order entry; local `splat ID` into the low 24 bits.
4. **Unified draw** (new) - one `Graphics.RenderMeshPrimitives` call binding a concatenated packed-splats buffer.

The per-renderer packed splat upload is unchanged. The one-time GPU upload still only happens when an asset loads.
What's new is a GPU-side concatenation step: when the active renderer set changes, a small `GsplatCopyBuffer.compute` copies each renderer's existing packed buffer into the matching sub-range of a shared global buffer. GPU→GPU, no CPU round-trip, and only runs when the set changes, not per frame.

### Integration with existing systems
 * A few new `IGsplat` members expose the per-renderer GPU buffers the sorter needs (PackedSplatsBuffer, SH1..SH4Buffer, SHBands, SplatCount). Existing members are unchanged.
 * `GsplatGlobalMaterial` is a new ScriptableObject that bundles the merge/copy compute shaders with the global draw material and a SH-band keyword variant cache. Auto-discovered from the package path, mirroring how `Materials[]` works.
 * `GsplatGlobal.shader` and `GsplatSparkGlobal.hlsl` mirror the structure of `Gsplat.shader` and `GsplatSpark.hlsl`, with the same SH_BANDS_0..4 multi-compile and the same SH unpacking.
 * All four phases (depth, sort, merge, draw) are wrapped in `ProfilingSamplers` so they show up cleanly in the Profiler.

### Trade-offs

- **Per-frame cost:** one extra merge pass (O(N log K) for N total splats across K renderers), offset by collapsing K per-renderer draws into one.
- **Memory cost:** roughly 2× the packed splat data on GPU. The per-renderer buffers stay resident (still used by depth, sort, and the fallback path), and the new global concatenated buffer is a GPU-side duplicate.

### Limitations

- **Spark compression only.** The merged buffer requires a uniform splat layout. Mixing uncompressed and spark is not going to work. Uncompressed uses 5 separate buffers while Spark uses 1 packed `uint4`. When any active renderer is uncompressed, global sort disables for the scene and everyone falls back to per-renderer rendering. A clear warning fires once per offending renderer.
- **≤ 255 active renderers** (renderer ID is packed into 8 bits).
- **Opt-in.** `EnableGlobalSort` defaults to `false`. Users with single-renderer scenes or uncompressed assets see no change unless they turn it on.

### Testing

- New scene with 2+ Spark renderers positioned so they should depth-interleave. Enable global sort, verify correct compositing; disable, verify the previous artefact returns.
- Single-renderer scene with global sort on. Confirms the count `>= 2` short-circuit, no extra GPU work.
- Mix one uncompressed renderer into a multi-renderer scene. One warning, scene falls back to per-renderer rendering, no crash, no per-frame noise.
- Built-in RP and URP exercised. HDRP not tested; it likely needs a parallel feature similar to `GsplatURPFeature` for `DrawAllIfEnabled` to fire.
- Profiler shows `Gsplat.DepthPerRenderer`, `Gsplat.SortPerRenderer`, `Gsplat.MergeKWay`, `Gsplat.DrawAll` for the four phases.


### Conclusion

For my use case the performance trade offs were worth it. Maybe it will be useful to other people as well. I don't know if the design I have chosen would be right to merge in, but I'm happy to iterate on this.
This PR would also need a more testing. I've been focused on Unity 6000.3.9f1 running URP. I'm sure there will be more bugs to find on other Unity versions and configurations.

Thanks,

Keir Rice