### PR TITLE
Fix CS0122 compile error in URP 

### DIFF
--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -70,7 +70,7 @@ namespace Gsplat
         readonly List<IGsplat> m_activeGsplats = new();
         readonly HashSet<int> m_warnedUncompressed = new();
         GsplatSortPass m_sortPass;
-        const string k_passName = "SortGsplats";
+        public const string k_passName = "SortGsplats";
         const string k_depthPassName = "Gsplat.ComputeDepth";
         const string k_radixSortPassName = "Gsplat.RadixSort";
 

--- a/Runtime/SRP/GsplatURPFeature.cs
+++ b/Runtime/SRP/GsplatURPFeature.cs
@@ -27,7 +27,7 @@ namespace Gsplat
 
             public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
             {
-                using var builder = renderGraph.AddUnsafePass(GsplatSorter.k_PassName, out PassData passData);
+                using var builder = renderGraph.AddUnsafePass(GsplatSorter.k_passName, out PassData passData);
                 passData.CameraData = frameData.Get<UniversalCameraData>();
                 builder.AllowPassCulling(false);
                 builder.SetRenderFunc(static (PassData data, UnsafeGraphContext context) =>


### PR DESCRIPTION
**GsplatURPFeature.cs** — `k_passName` was referenced as `k_PassName` 
(wrong casing), causing CS0122 inaccessible error. Fixed the casing to 
match the constant declared in GsplatSorter.cs.