### PR TITLE
Fix PLY header parsing to count only vertex element properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added optional global depth sorting across multiple GsplatRenderer instances, allowing splats from different renderers to interleave correctly in a single draw call. An option `Enable Global Sort` is added to `Project Settings > Gsplat` to enable this feature. Global sorting only supports assets with Spark compression. The package falls back to the per-renderer pipeline when any active `GsplatRenderer` using an uncompressed asset. ([#28](https://github.com/wuyize25/gsplat-unity/pull/28) by [@KeirRice](https://github.com/KeirRice))
 
+### Fixed
+
+- Fixed PLY header parsing to count only vertex element properties. The package now supports PLY files exported by Apple's [ml-sharp](https://github.com/apple/ml-sharp). ([#33](https://github.com/wuyize25/gsplat-unity/pull/33) by [@TakashiYoshinaga](https://github.com/TakashiYoshinaga))
+
 ## [1.3.0] - 2026-05-23
 
 ### Added

--- a/Runtime/GsplatAsset.cs
+++ b/Runtime/GsplatAsset.cs
@@ -92,11 +92,19 @@ namespace Gsplat
 
         public PlyHeaderInfo(FileStream fs)
         {
+            bool inVertexElement = false;
             while (ReadLine(fs) is { } line && line != "end_header")
             {
                 var tokens = line.Split(' ');
-                if (tokens.Length == 3 && tokens[0] == "element" && tokens[1] == "vertex")
-                    VertexCount = uint.Parse(tokens[2]);
+                if (tokens.Length >= 2 && tokens[0] == "element")
+                {
+                    inVertexElement = tokens.Length == 3 && tokens[1] == "vertex";
+                    if (inVertexElement)
+                        VertexCount = uint.Parse(tokens[2]);
+                    continue;
+                }
+
+                if (!inVertexElement) continue;
                 if (tokens.Length != 3 || tokens[0] != "property") continue;
                 switch (tokens[2])
                 {


### PR DESCRIPTION
## Problem

PLY files that contain additional elements besides `vertex` — for example files exported by Apple's [ml-sharp](https://github.com/apple/ml-sharp) — fail to import with `NotSupportedException: unexpected SH property count ...`.

`PlyHeaderInfo` counts every `property` line in the header regardless of which `element` block it belongs to, so properties of non-vertex elements are folded into `PropertyCount` / `SHPropertyCount`, corrupting the per-vertex stride and property offsets.

## Fix

Track the current element while parsing the header and only count properties that belong to the `element vertex` block. Extra elements are now ignored, and all offsets are computed strictly from the vertex element.

## Testing

Verified the parser logic against:
- a standard 3DGS PLY header (single vertex element, SH band 3) — identical results as before (no regression)
- headers with extra non-vertex elements before/after the vertex element — extra properties correctly ignored
- a header with no `f_rest_*` properties (SH band 0)

Also confirmed an ml-sharp exported PLY imports correctly in the Unity editor.