### PR TITLE
Add runtime PLY loading from byte arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added optional global depth sorting across multiple GsplatRenderer instances, allowing splats from different renderers to interleave correctly in a single draw call. An option `Enable Global Sort` is added to `Project Settings > Gsplat` to enable this feature. Global sorting only supports assets with Spark compression. The package falls back to the per-renderer pipeline when any active `GsplatRenderer` using an uncompressed asset. ([#28](https://github.com/wuyize25/gsplat-unity/pull/28) by [@KeirRice](https://github.com/KeirRice))
 
+- Added runtime PLY loading from byte arrays. A new method `LoadFromPlyBytes(byte[])` is added to `GsplatAsset` and its derived classes. ([#34](https://github.com/wuyize25/gsplat-unity/pull/34) by [@TakashiYoshinaga](https://github.com/TakashiYoshinaga))
+
 ### Fixed
 
 - Fixed PLY header parsing to count only vertex element properties. The package now supports PLY files exported by Apple's [ml-sharp](https://github.com/apple/ml-sharp). ([#33](https://github.com/wuyize25/gsplat-unity/pull/33) by [@TakashiYoshinaga](https://github.com/TakashiYoshinaga))

--- a/Editor/LoadFromPlyBytesManualTest.cs
+++ b/Editor/LoadFromPlyBytesManualTest.cs
@@ -1,0 +1,199 @@
+// Manual test for LoadFromPlyBytes.
+// Menu: Tools > Gsplat > Test LoadFromPlyBytes...
+// Loads the same PLY via LoadFromPly(path) and LoadFromPlyBytes(bytes) for both
+// compression modes and verifies the resulting assets are identical.
+
+using System;
+using System.IO;
+using Unity.Mathematics;
+using UnityEditor;
+using UnityEngine;
+
+namespace Gsplat.Editor
+{
+    static class LoadFromPlyBytesManualTest
+    {
+        static int s_failures;
+
+        [MenuItem("Tools/Gsplat/Test LoadFromPlyBytes...")]
+        static void Run()
+        {
+            var path = EditorUtility.OpenFilePanel("Select a PLY file", "", "ply");
+            if (string.IsNullOrEmpty(path)) return;
+
+            s_failures = 0;
+            var bytes = File.ReadAllBytes(path);
+
+            try
+            {
+                TestUncompressed(path, bytes);
+                TestSpark(path, bytes);
+                TestErrorCases();
+            }
+            finally
+            {
+                EditorUtility.ClearProgressBar();
+            }
+
+            if (s_failures == 0)
+                Debug.Log("<color=green>LoadFromPlyBytes test: ALL PASSED</color>");
+            else
+                Debug.LogError($"LoadFromPlyBytes test: {s_failures} FAILURES");
+        }
+
+        static void Check(string name, bool cond)
+        {
+            if (cond)
+                Debug.Log($"PASS {name}");
+            else
+            {
+                Debug.LogError($"FAIL {name}");
+                s_failures++;
+            }
+        }
+
+        static void TestUncompressed(string path, byte[] bytes)
+        {
+            var fromFile = ScriptableObject.CreateInstance<GsplatAssetUncompressed>();
+            var fromBytes = ScriptableObject.CreateInstance<GsplatAssetUncompressed>();
+            try
+            {
+                fromFile.LoadFromPly(path);
+                fromBytes.LoadFromPlyBytes(bytes);
+
+                Check("uncompressed SplatCount", fromFile.SplatCount == fromBytes.SplatCount);
+                Check("uncompressed SHBands", fromFile.SHBands == fromBytes.SHBands);
+                Check("uncompressed Bounds", fromFile.Bounds == fromBytes.Bounds);
+                CheckArray("uncompressed Positions", fromFile.Positions, fromBytes.Positions);
+                CheckArray("uncompressed Colors", fromFile.Colors, fromBytes.Colors);
+                CheckArray("uncompressed SHs", fromFile.SHs, fromBytes.SHs);
+                CheckArray("uncompressed Scales", fromFile.Scales, fromBytes.Scales);
+                CheckArray("uncompressed Rotations", fromFile.Rotations, fromBytes.Rotations);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(fromFile);
+                UnityEngine.Object.DestroyImmediate(fromBytes);
+            }
+        }
+
+        static void TestSpark(string path, byte[] bytes)
+        {
+            var fromFile = ScriptableObject.CreateInstance<GsplatAssetSpark>();
+            var fromBytes = ScriptableObject.CreateInstance<GsplatAssetSpark>();
+            try
+            {
+                fromFile.LoadFromPly(path);
+                fromBytes.LoadFromPlyBytes(bytes);
+
+                Check("spark SplatCount", fromFile.SplatCount == fromBytes.SplatCount);
+                Check("spark SHBands", fromFile.SHBands == fromBytes.SHBands);
+                Check("spark Bounds", fromFile.Bounds == fromBytes.Bounds);
+                CheckArray("spark PackedSplats", fromFile.PackedSplats, fromBytes.PackedSplats);
+                CheckArray("spark PackedSH1", fromFile.PackedSH1, fromBytes.PackedSH1);
+                CheckArray("spark PackedSH2", fromFile.PackedSH2, fromBytes.PackedSH2);
+                CheckArray("spark PackedSH3", fromFile.PackedSH3, fromBytes.PackedSH3);
+                CheckArray("spark PackedSH4", fromFile.PackedSH4, fromBytes.PackedSH4);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(fromFile);
+                UnityEngine.Object.DestroyImmediate(fromBytes);
+            }
+        }
+
+        static void TestErrorCases()
+        {
+            var uncompressed = ScriptableObject.CreateInstance<GsplatAssetUncompressed>();
+            var spz = ScriptableObject.CreateInstance<GsplatAssetSpz>();
+            var spzUncompressed = ScriptableObject.CreateInstance<GsplatAssetSpzUncompressed>();
+            try
+            {
+                Check("empty bytes throw ArgumentException",
+                    Throws<ArgumentException>(() => uncompressed.LoadFromPlyBytes(Array.Empty<byte>())));
+                Check("null bytes throw ArgumentException",
+                    Throws<ArgumentException>(() => uncompressed.LoadFromPlyBytes(null)));
+                Check("GsplatAssetSpz throws NotSupportedException",
+                    Throws<NotSupportedException>(() => spz.LoadFromPlyBytes(new byte[] { 1 })));
+                Check("GsplatAssetSpzUncompressed throws NotSupportedException",
+                    Throws<NotSupportedException>(() => spzUncompressed.LoadFromPlyBytes(new byte[] { 1 })));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(uncompressed);
+                UnityEngine.Object.DestroyImmediate(spz);
+                UnityEngine.Object.DestroyImmediate(spzUncompressed);
+            }
+        }
+
+        static bool Throws<T>(Action action) where T : Exception
+        {
+            try
+            {
+                action();
+                return false;
+            }
+            catch (T)
+            {
+                return true;
+            }
+        }
+
+        static void CheckArray<T>(string name, T[] a, T[] b) where T : IEquatable<T>
+        {
+            if (a == null || b == null)
+            {
+                Check(name, a == b);
+                return;
+            }
+
+            if (a.Length != b.Length)
+            {
+                Check($"{name} length ({a.Length} vs {b.Length})", false);
+                return;
+            }
+
+            for (var i = 0; i < a.Length; i++)
+                if (!a[i].Equals(b[i]))
+                {
+                    Check($"{name} element {i} ({a[i]} vs {b[i]})", false);
+                    return;
+                }
+
+            Check($"{name} ({a.Length} elements)", true);
+        }
+
+        static void CheckArray(string name, Vector3[] a, Vector3[] b) =>
+            CheckArrayExact(name, a, b, (x, y) => x == y);
+
+        static void CheckArray(string name, Vector4[] a, Vector4[] b) =>
+            CheckArrayExact(name, a, b, (x, y) => x == y);
+
+        static void CheckArray(string name, uint4[] a, uint4[] b) =>
+            CheckArrayExact(name, a, b, (x, y) => x.Equals(y));
+
+        static void CheckArrayExact<T>(string name, T[] a, T[] b, Func<T, T, bool> equals)
+        {
+            if (a == null || b == null)
+            {
+                Check(name, ReferenceEquals(a, b));
+                return;
+            }
+
+            if (a.Length != b.Length)
+            {
+                Check($"{name} length ({a.Length} vs {b.Length})", false);
+                return;
+            }
+
+            for (var i = 0; i < a.Length; i++)
+                if (!equals(a[i], b[i]))
+                {
+                    Check($"{name} element {i} ({a[i]} vs {b[i]})", false);
+                    return;
+                }
+
+            Check($"{name} ({a.Length} elements)", true);
+        }
+    }
+}

--- a/Editor/LoadFromPlyBytesManualTest.cs.meta
+++ b/Editor/LoadFromPlyBytesManualTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c00424c27f4a4d4ba90884bc858463a

--- a/Runtime/GsplatAsset.cs
+++ b/Runtime/GsplatAsset.cs
@@ -92,11 +92,19 @@ namespace Gsplat
 
         public PlyHeaderInfo(FileStream fs)
         {
+            bool inVertexElement = false;
             while (ReadLine(fs) is { } line && line != "end_header")
             {
                 var tokens = line.Split(' ');
-                if (tokens.Length == 3 && tokens[0] == "element" && tokens[1] == "vertex")
-                    VertexCount = uint.Parse(tokens[2]);
+                if (tokens.Length >= 2 && tokens[0] == "element")
+                {
+                    inVertexElement = tokens.Length == 3 && tokens[1] == "vertex";
+                    if (inVertexElement)
+                        VertexCount = uint.Parse(tokens[2]);
+                    continue;
+                }
+
+                if (!inVertexElement) continue;
                 if (tokens.Length != 3 || tokens[0] != "property") continue;
                 switch (tokens[2])
                 {

--- a/Runtime/GsplatAsset.cs
+++ b/Runtime/GsplatAsset.cs
@@ -71,7 +71,7 @@ namespace Gsplat
         /// </summary>
         /// <param name="fs"></param>
         /// <returns></returns>
-        static string ReadLine(FileStream fs)
+        static string ReadLine(Stream fs)
         {
             List<byte> byteBuffer = new List<byte>();
             while (true)
@@ -90,7 +90,7 @@ namespace Gsplat
             return Encoding.UTF8.GetString(byteBuffer.ToArray());
         }
 
-        public PlyHeaderInfo(FileStream fs)
+        public PlyHeaderInfo(Stream fs)
         {
             bool inVertexElement = false;
             while (ReadLine(fs) is { } line && line != "end_header")
@@ -155,6 +155,10 @@ namespace Gsplat
         public abstract void Allocate();
         public abstract void LoadFromPly(string plyPath, ProgressCallback progressCallback = null,
             SourceCoordinates sourceCoordinates = SourceCoordinates.RUF);
+
+        public virtual void LoadFromPlyBytes(byte[] plyBytes, ProgressCallback progressCallback = null,
+            SourceCoordinates sourceCoordinates = SourceCoordinates.RUF)
+            => throw new NotSupportedException($"{GetType().Name} does not support loading PLY from bytes.");
 
         public abstract GsplatResource CreateResource();
 

--- a/Runtime/GsplatAssetSpark.cs
+++ b/Runtime/GsplatAssetSpark.cs
@@ -170,6 +170,20 @@ namespace Gsplat
             if (fs.Length >= 2 * 1024 * 1024 * 1024L)
                 throw new NotSupportedException("currently files larger than 2GB are not supported");
 
+            LoadFromPlyStream(fs, progressCallback, sourceCoordinates);
+        }
+
+        public override void LoadFromPlyBytes(byte[] plyBytes, ProgressCallback progressCallback = null,
+            SourceCoordinates sourceCoordinates = SourceCoordinates.RUF)
+        {
+            if (plyBytes == null || plyBytes.Length == 0)
+                throw new ArgumentException("PLY byte array is null or empty.", nameof(plyBytes));
+            using var ms = new MemoryStream(plyBytes, writable: false);
+            LoadFromPlyStream(ms, progressCallback, sourceCoordinates);
+        }
+
+        void LoadFromPlyStream(Stream fs, ProgressCallback progressCallback, SourceCoordinates sourceCoordinates)
+        {
             var plyInfo = new PlyHeaderInfo(fs);
             var shCoeffs = plyInfo.SHPropertyCount / 3;
             SplatCount = plyInfo.VertexCount;

--- a/Runtime/GsplatAssetSpz.cs
+++ b/Runtime/GsplatAssetSpz.cs
@@ -55,6 +55,10 @@ namespace Gsplat
             SourceCoordinates sourceCoordinates = SourceCoordinates.RUF)
             => throw new NotSupportedException("GsplatAssetSpz loads SPZ files, not PLY.");
 
+        public override void LoadFromPlyBytes(byte[] plyBytes, ProgressCallback progressCallback = null,
+            SourceCoordinates sourceCoordinates = SourceCoordinates.RUF)
+            => throw new NotSupportedException("GsplatAssetSpz loads SPZ files, not PLY.");
+
         public SpzPhaseTimings LoadFromSpz(string spzPath,
             SourceCoordinates sourceCoordinates = SourceCoordinates.RUB,
             ProgressCallback progressCallback = null)

--- a/Runtime/GsplatAssetSpzUncompressed.cs
+++ b/Runtime/GsplatAssetSpzUncompressed.cs
@@ -13,6 +13,10 @@ namespace Gsplat
             SourceCoordinates sourceCoordinates = SourceCoordinates.RUF)
             => throw new System.NotSupportedException("GsplatAssetSpzUncompressed loads SPZ files, not PLY.");
 
+        public override void LoadFromPlyBytes(byte[] plyBytes, ProgressCallback progressCallback = null,
+            SourceCoordinates sourceCoordinates = SourceCoordinates.RUF)
+            => throw new System.NotSupportedException("GsplatAssetSpzUncompressed loads SPZ files, not PLY.");
+
         public SpzPhaseTimings LoadFromSpz(string spzPath,
             SourceCoordinates sourceCoordinates = SourceCoordinates.RUB,
             ProgressCallback progressCallback = null)

--- a/Runtime/GsplatAssetUncompressed.cs
+++ b/Runtime/GsplatAssetUncompressed.cs
@@ -131,6 +131,20 @@ namespace Gsplat
             if (fs.Length >= 2 * 1024 * 1024 * 1024L)
                 throw new NotSupportedException("currently files larger than 2GB are not supported");
 
+            LoadFromPlyStream(fs, progressCallback, sourceCoordinates);
+        }
+
+        public override void LoadFromPlyBytes(byte[] plyBytes, ProgressCallback progressCallback = null,
+            SourceCoordinates sourceCoordinates = SourceCoordinates.RUF)
+        {
+            if (plyBytes == null || plyBytes.Length == 0)
+                throw new ArgumentException("PLY byte array is null or empty.", nameof(plyBytes));
+            using var ms = new MemoryStream(plyBytes, writable: false);
+            LoadFromPlyStream(ms, progressCallback, sourceCoordinates);
+        }
+
+        void LoadFromPlyStream(Stream fs, ProgressCallback progressCallback, SourceCoordinates sourceCoordinates)
+        {
             var plyInfo = new PlyHeaderInfo(fs);
             var shCoeffs = plyInfo.SHPropertyCount / 3;
             SplatCount = plyInfo.VertexCount;

--- a/Runtime/RuntimePlyBytesLoaderTest.cs
+++ b/Runtime/RuntimePlyBytesLoaderTest.cs
@@ -1,0 +1,44 @@
+// Manual test for LoadFromPlyBytes.
+// Add to a GameObject together with GsplatRenderer, set PlyPath (absolute, or relative
+// to StreamingAssets), and enter Play mode. The PLY is read with File.ReadAllBytes and
+// loaded via LoadFromPlyBytes — no importer / asset file involved — then rendered.
+
+using System.IO;
+using UnityEngine;
+
+namespace Gsplat
+{
+    [RequireComponent(typeof(GsplatRenderer))]
+    public class RuntimePlyBytesLoaderTest : MonoBehaviour
+    {
+        [Tooltip("Absolute path, or relative to StreamingAssets")]
+        public string PlyPath;
+
+        public CompressionMode Compression = CompressionMode.Spark;
+        public SourceCoordinates SourceCoordinates = SourceCoordinates.RUB;
+
+        void Start()
+        {
+            var path = Path.IsPathRooted(PlyPath)
+                ? PlyPath
+                : Path.Combine(Application.streamingAssetsPath, PlyPath);
+            if (!File.Exists(path))
+            {
+                Debug.LogError($"PLY not found: {path}");
+                return;
+            }
+
+            // Simulates data arriving as a byte array (e.g. downloaded at runtime).
+            var bytes = File.ReadAllBytes(path);
+
+            GsplatAsset asset = Compression == CompressionMode.Spark
+                ? ScriptableObject.CreateInstance<GsplatAssetSpark>()
+                : ScriptableObject.CreateInstance<GsplatAssetUncompressed>();
+            asset.LoadFromPlyBytes(bytes, null, SourceCoordinates);
+
+            GetComponent<GsplatRenderer>().GsplatAsset = asset;
+            Debug.Log($"Loaded {asset.SplatCount} splats (SH bands {asset.SHBands}) " +
+                      $"from {bytes.Length} bytes via LoadFromPlyBytes");
+        }
+    }
+}

--- a/Runtime/RuntimePlyBytesLoaderTest.cs.meta
+++ b/Runtime/RuntimePlyBytesLoaderTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d09690e2fec10499a8d9cfde874dac88


### PR DESCRIPTION
## Motivation

Currently PLY data can only be loaded from a file path via `LoadFromPly(string)`.
This PR adds `LoadFromPlyBytes(byte[])` so PLY data can be loaded without a file on
disk — for example, data downloaded at runtime or received over the network, which
can then be visualized directly with `GsplatRenderer`.

## Changes

- `PlyHeaderInfo` and its `ReadLine` helper accept `Stream` instead of `FileStream`
  (only `ReadByte` is used, so this is a safe widening)
- `GsplatAsset` gains `virtual LoadFromPlyBytes(byte[], ...)`, throwing
  `NotSupportedException` by default
- `GsplatAssetUncompressed` / `GsplatAssetSpark`: the body of `LoadFromPly` is extracted
  into a shared `LoadFromPlyStream(Stream, ...)` helper; `LoadFromPly` keeps the
  `FileStream` opening and the 2GB guard. `LoadFromPlyBytes` wraps the bytes in a
  read-only `MemoryStream`. **The header-parsing and vertex-reading logic itself is
  unchanged.**
- The SPZ asset classes override `LoadFromPlyBytes` to throw, matching `LoadFromPly`
- Includes two manual tests (see "How to test" below)

## How to test

### 1. Editor test — verifies byte-based loading matches path-based loading

1. Open a Unity project that includes this package
2. Run **Tools > Gsplat > Test LoadFromPlyBytes...** from the menu bar
3. Select any 3DGS `.ply` file in the file dialog
4. Check the Console: each comparison logs `PASS`/`FAIL`, ending with
   **`LoadFromPlyBytes test: ALL PASSED`** on success

The test loads the selected file twice — via `LoadFromPly(path)` and via
`LoadFromPlyBytes(File.ReadAllBytes(path))` — for both compression modes, and verifies
the resulting assets are identical (SplatCount / SHBands / Bounds and all data arrays
compared element-wise). It also checks the error cases (null/empty byte array, SPZ
asset classes). Nothing is written to the project; all assets are created in memory
and destroyed afterwards.

### 2. Runtime test — visualizes a PLY loaded from a byte array

1. Create an empty GameObject in a scene and add **GsplatRenderer** and
   **RuntimePlyBytesLoaderTest** to it
2. Set **Ply Path** to a `.ply` file (absolute path, or relative to StreamingAssets),
   and pick Compression / Source Coordinates as appropriate
3. Enter Play mode

The component reads the file with `File.ReadAllBytes` and loads it via
`LoadFromPlyBytes` — no importer or asset file involved, simulating data received at
runtime — then assigns the asset to the `GsplatRenderer`, which should display the
splats.

## Testing done

- Editor test passes for standard 3DGS PLYs in both Uncompressed and Spark modes
- Confirmed rendering at runtime from a byte array via the runtime test component
- Existing importer path is untouched apart from the method extraction

## Note

This branch is based on #33 , so its first commit is that fix and it currently shows in
the diff as well. Once #33  is merged, this PR reduces to the byte-array loading change
only. Happy to rebase after the merge if needed.