### PR TITLE
Add optional depth prepass and explicit SRP splat rendering

### DIFF
--- a/Editor/GsplatSettingsProvider.cs
+++ b/Editor/GsplatSettingsProvider.cs
@@ -26,6 +26,7 @@ namespace Gsplat.Editor
             EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.ComputeShader)));
             EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.SplatInstanceSize)));
             EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.UploadBatchSize)));
+            EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.DepthPrepassAlphaCutoff)));
             EditorGUILayout.PropertyField(m_gsplatSettings.FindProperty(nameof(GsplatSettings.MaxRenderOrder)));
             EditorGUILayout.PropertyField(
                 m_gsplatSettings.FindProperty(nameof(GsplatSettings.CameraTranslationRefreshTreshold)));

--- a/Runtime/GsplatGlobalMaterial.cs
+++ b/Runtime/GsplatGlobalMaterial.cs
@@ -9,10 +9,12 @@ namespace Gsplat
     public class GsplatGlobalMaterial : ScriptableObject
     {
         public Material DefaultMaterial;
+        public Material DefaultDepthMaterial;
         public ComputeShader MergeShader;
         public ComputeShader CopyBufferShader;
 
         Material[] m_materials; // indexed by SH band (0–4)
+        Material[] m_depthMaterials; // indexed by SH band (0–4)
 
         /// <summary>
         /// Returns five Material instances — one per SH band level — with the appropriate
@@ -41,8 +43,35 @@ namespace Gsplat
             }
         }
 
-        public void Reset() => m_materials = null;
+        public Material[] DepthMaterials
+        {
+            get
+            {
+                if (m_depthMaterials != null && m_depthMaterials[0] != null)
+                    return m_depthMaterials;
 
-        public bool Valid() => MergeShader && CopyBufferShader && DefaultMaterial;
+                m_depthMaterials = new Material[5];
+                for (int i = 0; i < 5; i++)
+                {
+                    m_depthMaterials[i] = new Material(DefaultDepthMaterial);
+                    m_depthMaterials[i].DisableKeyword("SH_BANDS_0");
+                    m_depthMaterials[i].DisableKeyword("SH_BANDS_1");
+                    m_depthMaterials[i].DisableKeyword("SH_BANDS_2");
+                    m_depthMaterials[i].DisableKeyword("SH_BANDS_3");
+                    m_depthMaterials[i].DisableKeyword("SH_BANDS_4");
+                    m_depthMaterials[i].EnableKeyword($"SH_BANDS_{i}");
+                }
+
+                return m_depthMaterials;
+            }
+        }
+
+        public void Reset()
+        {
+            m_materials = null;
+            m_depthMaterials = null;
+        }
+
+        public bool Valid() => MergeShader && CopyBufferShader && DefaultMaterial && DefaultDepthMaterial;
     }
 }

--- a/Runtime/GsplatGlobalRenderer.cs
+++ b/Runtime/GsplatGlobalRenderer.cs
@@ -57,6 +57,7 @@ namespace Gsplat
         Matrix4x4[] m_rendererTransformsCache;
         RendererParams[] m_rendererParamsCache;
         MaterialPropertyBlock m_globalPropertyBlock;
+        int m_renderLayer;
 
         public bool Valid => m_globalMaterial
                              && m_globalMaterial.Valid()
@@ -156,6 +157,7 @@ namespace Gsplat
         {
             EnsureGlobalBuffers(activeGsplats);
             if (m_totalSplatCount == 0) return;
+            m_renderLayer = (activeGsplats[0] as Component)?.gameObject.layer ?? 0;
             UpdateRendererTransforms(activeGsplats);
             UpdateRendererParams(activeGsplats);
             Render();
@@ -492,7 +494,8 @@ namespace Gsplat
             var rp = new RenderParams(m_globalMaterial.Materials[m_globalSHBands])
             {
                 worldBounds = new Bounds(Vector3.zero, Vector3.one * 1e6f),
-                matProps = m_globalPropertyBlock
+                matProps = m_globalPropertyBlock,
+                layer = m_renderLayer
             };
 
             int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);

--- a/Runtime/GsplatGlobalRenderer.cs
+++ b/Runtime/GsplatGlobalRenderer.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
+#if UNITY_6000_0_OR_NEWER
+using UnityEngine.Rendering.RenderGraphModule;
+#endif
 
 namespace Gsplat
 {
@@ -159,7 +162,8 @@ namespace Gsplat
             if (m_totalSplatCount == 0) return;
             UpdateRendererTransforms(activeGsplats);
             UpdateRendererParams(activeGsplats);
-            Render();
+            if (!GraphicsSettings.currentRenderPipeline)
+                Render();
         }
 
         public void DispatchMerge(CommandBuffer cmd, List<IGsplat> activeGsplats)
@@ -499,6 +503,81 @@ namespace Gsplat
 
             int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
             Graphics.RenderMeshPrimitives(rp, GsplatSettings.Instance.Mesh, 0, instances);
+        }
+
+        public void RenderColor(CommandBuffer cmd)
+        {
+            if (m_globalBuffersDirty || m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
+
+            BindGlobalDrawProperties();
+
+            int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            cmd.DrawMeshInstancedProcedural(GsplatSettings.Instance.Mesh, 0, m_globalMaterial.Materials[m_globalSHBands],
+                0, instances, m_globalPropertyBlock);
+        }
+
+        public void RenderDepthPrepass(CommandBuffer cmd)
+        {
+            if (GsplatSettings.Instance.DepthPrepassAlphaCutoff > 1.0f)
+                return;
+
+            if (m_globalBuffersDirty || m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
+
+            BindGlobalDrawProperties();
+
+            int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            cmd.DrawMeshInstancedProcedural(GsplatSettings.Instance.Mesh, 0,
+                m_globalMaterial.DepthMaterials[m_globalSHBands], 0, instances, m_globalPropertyBlock);
+        }
+
+#if UNITY_6000_0_OR_NEWER
+        public void RenderColor(RasterCommandBuffer cmd)
+        {
+            if (m_globalBuffersDirty || m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
+
+            BindGlobalDrawProperties();
+
+            int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            cmd.DrawMeshInstancedProcedural(GsplatSettings.Instance.Mesh, 0, m_globalMaterial.Materials[m_globalSHBands],
+                0, instances, m_globalPropertyBlock);
+        }
+
+        public void RenderDepthPrepass(RasterCommandBuffer cmd)
+        {
+            if (GsplatSettings.Instance.DepthPrepassAlphaCutoff > 1.0f)
+                return;
+
+            if (m_globalBuffersDirty || m_globalOrderBuffer == null || m_totalRemainingCount == 0) return;
+
+            BindGlobalDrawProperties();
+
+            int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            cmd.DrawMeshInstancedProcedural(GsplatSettings.Instance.Mesh, 0,
+                m_globalMaterial.DepthMaterials[m_globalSHBands], 0, instances, m_globalPropertyBlock);
+        }
+#endif
+
+        void BindGlobalDrawProperties()
+        {
+            m_globalPropertyBlock ??= new MaterialPropertyBlock();
+            m_globalPropertyBlock.Clear();
+            m_globalPropertyBlock.SetBuffer(k_globalOrderBuffer, m_globalOrderBuffer);
+            m_globalPropertyBlock.SetBuffer(k_globalPackedBuffer, m_globalPackedBuffer);
+            m_globalPropertyBlock.SetBuffer(k_rendererOffsetsProp, m_rendererOffsetsBuffer);
+            m_globalPropertyBlock.SetBuffer(k_rendererTransformsProp, m_rendererTransformsBuffer);
+            m_globalPropertyBlock.SetBuffer(k_rendererParamsProp, m_rendererParamsBuffer);
+            m_globalPropertyBlock.SetInteger(k_totalSplatCount, (int)m_totalRemainingCount);
+            m_globalPropertyBlock.SetInteger(k_splatInstanceSize, (int)GsplatSettings.Instance.SplatInstanceSize);
+            m_globalPropertyBlock.SetFloat(k_depthPrepassAlphaCutoff, GsplatSettings.Instance.DepthPrepassAlphaCutoff);
+
+            if (m_globalSHBands >= 1)
+                m_globalPropertyBlock.SetBuffer(k_globalSH1Buffer, m_globalSH1Buffer);
+            if (m_globalSHBands >= 2)
+                m_globalPropertyBlock.SetBuffer(k_globalSH2Buffer, m_globalSH2Buffer);
+            if (m_globalSHBands >= 3)
+                m_globalPropertyBlock.SetBuffer(k_globalSH3Buffer, m_globalSH3Buffer);
+            if (m_globalSHBands >= 4)
+                m_globalPropertyBlock.SetBuffer(k_globalSH4Buffer, m_globalSH4Buffer);
         }
 
 

--- a/Runtime/GsplatGlobalRenderer.cs
+++ b/Runtime/GsplatGlobalRenderer.cs
@@ -111,6 +111,7 @@ namespace Gsplat
         static readonly int k_rendererParamsProp = Shader.PropertyToID("_RendererParams");
         static readonly int k_totalSplatCount = Shader.PropertyToID("_TotalSplatCount");
         static readonly int k_splatInstanceSize = Shader.PropertyToID("_SplatInstanceSize");
+        static readonly int k_depthPrepassAlphaCutoff = Shader.PropertyToID("_DepthPrepassAlphaCutoff");
 
         public void InitGlobal(GsplatGlobalMaterial globalMaterial)
         {
@@ -479,6 +480,7 @@ namespace Gsplat
             m_globalPropertyBlock.SetBuffer(k_rendererParamsProp, m_rendererParamsBuffer);
             m_globalPropertyBlock.SetInteger(k_totalSplatCount, (int)m_totalRemainingCount);
             m_globalPropertyBlock.SetInteger(k_splatInstanceSize, (int)GsplatSettings.Instance.SplatInstanceSize);
+            m_globalPropertyBlock.SetFloat(k_depthPrepassAlphaCutoff, GsplatSettings.Instance.DepthPrepassAlphaCutoff);
 
             if (m_globalSHBands >= 1)
                 m_globalPropertyBlock.SetBuffer(k_globalSH1Buffer, m_globalSH1Buffer);

--- a/Runtime/GsplatGlobalRenderer.cs
+++ b/Runtime/GsplatGlobalRenderer.cs
@@ -157,7 +157,7 @@ namespace Gsplat
         {
             EnsureGlobalBuffers(activeGsplats);
             if (m_totalSplatCount == 0) return;
-            m_renderLayer = (activeGsplats[0] as Component)?.gameObject.layer ?? 0;
+            m_renderLayer = activeGsplats[0].transform.gameObject.layer;
             UpdateRendererTransforms(activeGsplats);
             UpdateRendererParams(activeGsplats);
             Render();

--- a/Runtime/GsplatMaterial.cs
+++ b/Runtime/GsplatMaterial.cs
@@ -9,11 +9,14 @@ namespace Gsplat
     public class GsplatMaterial : ScriptableObject
     {
         public Material DefaultMaterial;
+        public Material DefaultDepthMaterial;
         private Material[][] m_material;
+        private Material[][] m_depthMaterial;
 
         public void Reset()
         {
             m_material = null;
+            m_depthMaterial = null;
         }
 
         public Material[][] Materials // materials generated with SH bands from 0 to 4 and custom renderOrders
@@ -40,6 +43,33 @@ namespace Gsplat
                     }
                 }
                 return m_material;
+            }
+        }
+
+        public Material[][] DepthMaterials
+        {
+            get
+            {
+                if (m_depthMaterial != null && m_depthMaterial[0][0] != null)
+                    return m_depthMaterial;
+
+                m_depthMaterial = new Material[5][];
+                for (var i = 0; i < 5; ++i)
+                {
+                    m_depthMaterial[i] = new Material[GsplatSettings.Instance.MaxRenderOrder];
+                    for (var j = 0; j < GsplatSettings.Instance.MaxRenderOrder; ++j)
+                    {
+                        m_depthMaterial[i][j] = new Material(DefaultDepthMaterial);
+                        m_depthMaterial[i][j].DisableKeyword($"SH_BANDS_0");
+                        m_depthMaterial[i][j].DisableKeyword($"SH_BANDS_1");
+                        m_depthMaterial[i][j].DisableKeyword($"SH_BANDS_2");
+                        m_depthMaterial[i][j].DisableKeyword($"SH_BANDS_3");
+                        m_depthMaterial[i][j].DisableKeyword($"SH_BANDS_4");
+                        m_depthMaterial[i][j].EnableKeyword($"SH_BANDS_{i}");
+                        m_depthMaterial[i][j].renderQueue = 3000 + j;
+                    }
+                }
+                return m_depthMaterial;
             }
         }
 

--- a/Runtime/GsplatRenderer.cs
+++ b/Runtime/GsplatRenderer.cs
@@ -163,12 +163,17 @@ namespace Gsplat
             {
                 m_renderer.EvaluateRefreshRequired(SortMode, SortRefreshRate - 1, CutoutsRefreshRate - 1);
                 m_renderer.DispatchInitOrder(Cutouts, transform.localToWorldMatrix, CutoutsUpdateBounds);
-                // When the global sorter has merged all renderers into a single draw call,
-                // skip the per-renderer draw — GsplatSorter.DrawAll handles rendering.
-                if (!GsplatSorter.Instance.GlobalRenderEnabled)
-                    m_renderer.Render(transform, gameObject.layer, GammaToLinear, SHDegree, Brightness,
-                        1.0f - SplatDownscaleFactor, RenderOrder);
             }
+        }
+
+        // Called by GsplatSorter after it has selected one render path for the frame.
+        internal void Render()
+        {
+            if (!Valid || !GsplatSettings.Instance.Valid || !GsplatSorter.Instance.Valid)
+                return;
+
+            m_renderer.Render(transform, gameObject.layer, GammaToLinear, SHDegree, Brightness,
+                1.0f - SplatDownscaleFactor, RenderOrder);
         }
     }
 }

--- a/Runtime/GsplatRenderer.cs
+++ b/Runtime/GsplatRenderer.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
+#if UNITY_6000_0_OR_NEWER
+using UnityEngine.Rendering.RenderGraphModule;
+#endif
 
 namespace Gsplat
 {
@@ -87,6 +90,30 @@ namespace Gsplat
 
         public void ComputeDepth(CommandBuffer cmd, Matrix4x4 matrixMv) => m_renderer.ComputeDepth(cmd, matrixMv);
 
+        public void RenderColor(CommandBuffer cmd, Camera camera)
+        {
+            m_renderer.RenderColor(cmd, transform, GammaToLinear, SHDegree, Brightness,
+                1.0f - SplatDownscaleFactor, RenderOrder);
+        }
+
+        public void RenderDepthPrepass(CommandBuffer cmd, Camera camera)
+        {
+            m_renderer.RenderDepthPrepass(cmd, transform, 1.0f - SplatDownscaleFactor, RenderOrder);
+        }
+
+#if UNITY_6000_0_OR_NEWER
+        public void RenderColor(RasterCommandBuffer cmd, Camera camera)
+        {
+            m_renderer.RenderColor(cmd, transform, GammaToLinear, SHDegree, Brightness,
+                1.0f - SplatDownscaleFactor, RenderOrder);
+        }
+
+        public void RenderDepthPrepass(RasterCommandBuffer cmd, Camera camera)
+        {
+            m_renderer.RenderDepthPrepass(cmd, transform, 1.0f - SplatDownscaleFactor, RenderOrder);
+        }
+#endif
+
         void OnEnable()
         {
             GsplatSorter.Instance.RegisterGsplat(this);
@@ -165,7 +192,7 @@ namespace Gsplat
                 m_renderer.DispatchInitOrder(Cutouts, transform.localToWorldMatrix, CutoutsUpdateBounds);
                 // When the global sorter has merged all renderers into a single draw call,
                 // skip the per-renderer draw — GsplatSorter.DrawAll handles rendering.
-                if (!GsplatSorter.Instance.GlobalRenderEnabled)
+                if (!GraphicsSettings.currentRenderPipeline && !GsplatSorter.Instance.GlobalRenderEnabled)
                     m_renderer.Render(transform, gameObject.layer, GammaToLinear, SHDegree, Brightness,
                         1.0f - SplatDownscaleFactor, RenderOrder);
             }

--- a/Runtime/GsplatRendererImpl.cs
+++ b/Runtime/GsplatRendererImpl.cs
@@ -34,6 +34,7 @@ namespace Gsplat
         static readonly int k_shDegree = Shader.PropertyToID("_SHDegree");
         static readonly int k_brightness = Shader.PropertyToID("_Brightness");
         static readonly int k_scaleFactor = Shader.PropertyToID("_ScaleFactor");
+        static readonly int k_depthPrepassAlphaCutoff = Shader.PropertyToID("_DepthPrepassAlphaCutoff");
 
         uint m_framesBeforeRecomputeSort = 0;
         uint m_sortsBeforeRecomputeCutouts = 0;
@@ -272,6 +273,7 @@ namespace Gsplat
             m_propertyBlock.SetInteger(k_shDegree, Math.Min(m_gsplatAsset.SHBands, shDegree));
             m_propertyBlock.SetFloat(k_brightness, brightness);
             m_propertyBlock.SetFloat(k_scaleFactor, scaleFactor);
+            m_propertyBlock.SetFloat(k_depthPrepassAlphaCutoff, GsplatSettings.Instance.DepthPrepassAlphaCutoff);
             m_propertyBlock.SetMatrix(k_matrixM, transform.localToWorldMatrix);
 
             uint order = Math.Clamp(renderOrder, 0, GsplatSettings.Instance.MaxRenderOrder - 1);

--- a/Runtime/GsplatRendererImpl.cs
+++ b/Runtime/GsplatRendererImpl.cs
@@ -5,6 +5,9 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
+#if UNITY_6000_0_OR_NEWER
+using UnityEngine.Rendering.RenderGraphModule;
+#endif
 using Vector3 = UnityEngine.Vector3;
 
 namespace Gsplat
@@ -287,5 +290,89 @@ namespace Gsplat
             Graphics.RenderMeshPrimitives(rp, GsplatSettings.Instance.Mesh, 0,
                 Mathf.CeilToInt(m_remainingCount / (float)GsplatSettings.Instance.SplatInstanceSize));
         }
+
+        public void RenderDepthPrepass(CommandBuffer cmd, Transform transform, float scaleFactor = 1.0f,
+            uint renderOrder = 0)
+        {
+            if (m_remainingCount <= 0 || GsplatSettings.Instance.DepthPrepassAlphaCutoff > 1.0f)
+                return;
+
+            m_propertyBlock.SetInteger(k_splatCount, (int)m_remainingCount);
+            m_propertyBlock.SetInteger(k_splatInstanceSize, (int)GsplatSettings.Instance.SplatInstanceSize);
+            m_propertyBlock.SetFloat(k_scaleFactor, scaleFactor);
+            m_propertyBlock.SetFloat(k_depthPrepassAlphaCutoff, GsplatSettings.Instance.DepthPrepassAlphaCutoff);
+            m_propertyBlock.SetMatrix(k_matrixM, transform.localToWorldMatrix);
+
+            uint order = Math.Clamp(renderOrder, 0, GsplatSettings.Instance.MaxRenderOrder - 1);
+            int instances = Mathf.CeilToInt(m_remainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            cmd.DrawMeshInstancedProcedural(GsplatSettings.Instance.Mesh, 0,
+                m_gsplatAsset.GsplatMaterial.DepthMaterials[m_gsplatAsset.SHBands][order], 0, instances,
+                m_propertyBlock);
+        }
+
+#if UNITY_6000_0_OR_NEWER
+        public void RenderDepthPrepass(RasterCommandBuffer cmd, Transform transform, float scaleFactor = 1.0f,
+            uint renderOrder = 0)
+        {
+            if (m_remainingCount <= 0 || GsplatSettings.Instance.DepthPrepassAlphaCutoff > 1.0f)
+                return;
+
+            m_propertyBlock.SetInteger(k_splatCount, (int)m_remainingCount);
+            m_propertyBlock.SetInteger(k_splatInstanceSize, (int)GsplatSettings.Instance.SplatInstanceSize);
+            m_propertyBlock.SetFloat(k_scaleFactor, scaleFactor);
+            m_propertyBlock.SetFloat(k_depthPrepassAlphaCutoff, GsplatSettings.Instance.DepthPrepassAlphaCutoff);
+            m_propertyBlock.SetMatrix(k_matrixM, transform.localToWorldMatrix);
+
+            uint order = Math.Clamp(renderOrder, 0, GsplatSettings.Instance.MaxRenderOrder - 1);
+            int instances = Mathf.CeilToInt(m_remainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            cmd.DrawMeshInstancedProcedural(GsplatSettings.Instance.Mesh, 0,
+                m_gsplatAsset.GsplatMaterial.DepthMaterials[m_gsplatAsset.SHBands][order], 0, instances,
+                m_propertyBlock);
+        }
+#endif
+
+        public void RenderColor(CommandBuffer cmd, Transform transform, bool gammaToLinear = false, int shDegree = 3,
+            float brightness = 1.0f, float scaleFactor = 1.0f, uint renderOrder = 0)
+        {
+            if (m_remainingCount <= 0)
+                return;
+
+            m_propertyBlock.SetInteger(k_splatCount, (int)m_remainingCount);
+            m_propertyBlock.SetInteger(k_gammaToLinear, gammaToLinear ? 1 : 0);
+            m_propertyBlock.SetInteger(k_splatInstanceSize, (int)GsplatSettings.Instance.SplatInstanceSize);
+            m_propertyBlock.SetInteger(k_shDegree, Math.Min(m_gsplatAsset.SHBands, shDegree));
+            m_propertyBlock.SetFloat(k_brightness, brightness);
+            m_propertyBlock.SetFloat(k_scaleFactor, scaleFactor);
+            m_propertyBlock.SetFloat(k_depthPrepassAlphaCutoff, GsplatSettings.Instance.DepthPrepassAlphaCutoff);
+            m_propertyBlock.SetMatrix(k_matrixM, transform.localToWorldMatrix);
+
+            uint order = Math.Clamp(renderOrder, 0, GsplatSettings.Instance.MaxRenderOrder - 1);
+            int instances = Mathf.CeilToInt(m_remainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            cmd.DrawMeshInstancedProcedural(GsplatSettings.Instance.Mesh, 0, m_gsplatAsset.Materials[order], 0,
+                instances, m_propertyBlock);
+        }
+
+#if UNITY_6000_0_OR_NEWER
+        public void RenderColor(RasterCommandBuffer cmd, Transform transform, bool gammaToLinear = false,
+            int shDegree = 3, float brightness = 1.0f, float scaleFactor = 1.0f, uint renderOrder = 0)
+        {
+            if (m_remainingCount <= 0)
+                return;
+
+            m_propertyBlock.SetInteger(k_splatCount, (int)m_remainingCount);
+            m_propertyBlock.SetInteger(k_gammaToLinear, gammaToLinear ? 1 : 0);
+            m_propertyBlock.SetInteger(k_splatInstanceSize, (int)GsplatSettings.Instance.SplatInstanceSize);
+            m_propertyBlock.SetInteger(k_shDegree, Math.Min(m_gsplatAsset.SHBands, shDegree));
+            m_propertyBlock.SetFloat(k_brightness, brightness);
+            m_propertyBlock.SetFloat(k_scaleFactor, scaleFactor);
+            m_propertyBlock.SetFloat(k_depthPrepassAlphaCutoff, GsplatSettings.Instance.DepthPrepassAlphaCutoff);
+            m_propertyBlock.SetMatrix(k_matrixM, transform.localToWorldMatrix);
+
+            uint order = Math.Clamp(renderOrder, 0, GsplatSettings.Instance.MaxRenderOrder - 1);
+            int instances = Mathf.CeilToInt(m_remainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);
+            cmd.DrawMeshInstancedProcedural(GsplatSettings.Instance.Mesh, 0, m_gsplatAsset.Materials[order], 0,
+                instances, m_propertyBlock);
+        }
+#endif
     }
 }

--- a/Runtime/GsplatSettings.cs
+++ b/Runtime/GsplatSettings.cs
@@ -76,6 +76,8 @@ namespace Gsplat
 
         public uint SplatInstanceSize;
         public uint UploadBatchSize;
+        [Tooltip("Alpha cutoff used by the optional depth prepass. Values above 1 disable depth writes.")]
+        [Range(0f, 1.1f)] public float DepthPrepassAlphaCutoff = 1.1f;
         [Range(1, 20)] public uint MaxRenderOrder;
         public bool DisplayBoundingBoxes;
 
@@ -136,6 +138,7 @@ namespace Gsplat
             Materials = DefaultMaterials;
             SplatInstanceSize = 128;
             UploadBatchSize = 100000;
+            DepthPrepassAlphaCutoff = 1.1f;
             MaxRenderOrder = 1;
             DisplayBoundingBoxes = false;
             CameraTranslationRefreshTreshold = 0.2f;

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -167,8 +167,8 @@ namespace Gsplat
 
             // A single global draw can only have one Unity layer. Mixed-layer sets must retain
             // per-renderer draws so each camera's culling mask is respected.
-            var renderLayer = (m_activeGsplats[0] as Component)?.gameObject.layer ?? 0;
-            if (m_activeGsplats.Any(gs => ((gs as Component)?.gameObject.layer ?? 0) != renderLayer))
+            var renderLayer = m_activeGsplats[0].transform.gameObject.layer;
+            if (m_activeGsplats.Any(gs => gs.transform.gameObject.layer != renderLayer))
                 return false;
 
             return true;

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
+#if UNITY_6000_0_OR_NEWER
+using UnityEngine.Rendering.RenderGraphModule;
+#endif
 
 namespace Gsplat
 {
@@ -18,6 +21,12 @@ namespace Gsplat
         public bool Valid { get; }
         public bool ComputeSortRequired { get; }
         public void ComputeDepth(CommandBuffer cmd, Matrix4x4 matrixMv);
+        public void RenderColor(CommandBuffer cmd, Camera camera);
+        public void RenderDepthPrepass(CommandBuffer cmd, Camera camera);
+#if UNITY_6000_0_OR_NEWER
+        public void RenderColor(RasterCommandBuffer cmd, Camera camera);
+        public void RenderDepthPrepass(RasterCommandBuffer cmd, Camera camera);
+#endif
 
         // Used by GsplatSorter to populate the global packed buffer.
         public GsplatResource GsplatResource { get; }
@@ -234,6 +243,76 @@ namespace Gsplat
             if (GlobalRenderEnabled)
                 m_globalRenderer.DispatchMerge(cmd, m_activeGsplats);
         }
+
+        public void RenderDepthPrepass(CommandBuffer cmd, Camera camera)
+        {
+            if (GlobalRenderEnabled)
+            {
+                m_globalRenderer.RenderDepthPrepass(cmd);
+                return;
+            }
+
+            foreach (var gs in m_activeGsplats)
+            {
+                if (gs.RemainingCount <= 0) continue;
+                var layer = (gs as Component)?.gameObject.layer ?? 0;
+                if (camera && (camera.cullingMask & (1 << layer)) == 0) continue;
+                gs.RenderDepthPrepass(cmd, camera);
+            }
+        }
+
+        public void RenderColor(CommandBuffer cmd, Camera camera)
+        {
+            if (GlobalRenderEnabled)
+            {
+                m_globalRenderer.RenderColor(cmd);
+                return;
+            }
+
+            foreach (var gs in m_activeGsplats)
+            {
+                if (gs.RemainingCount <= 0) continue;
+                var layer = (gs as Component)?.gameObject.layer ?? 0;
+                if (camera && (camera.cullingMask & (1 << layer)) == 0) continue;
+                gs.RenderColor(cmd, camera);
+            }
+        }
+
+#if UNITY_6000_0_OR_NEWER
+        public void RenderDepthPrepass(RasterCommandBuffer cmd, Camera camera)
+        {
+            if (GlobalRenderEnabled)
+            {
+                m_globalRenderer.RenderDepthPrepass(cmd);
+                return;
+            }
+
+            foreach (var gs in m_activeGsplats)
+            {
+                if (gs.RemainingCount <= 0) continue;
+                var layer = (gs as Component)?.gameObject.layer ?? 0;
+                if (camera && (camera.cullingMask & (1 << layer)) == 0) continue;
+                gs.RenderDepthPrepass(cmd, camera);
+            }
+        }
+
+        public void RenderColor(RasterCommandBuffer cmd, Camera camera)
+        {
+            if (GlobalRenderEnabled)
+            {
+                m_globalRenderer.RenderColor(cmd);
+                return;
+            }
+
+            foreach (var gs in m_activeGsplats)
+            {
+                if (gs.RemainingCount <= 0) continue;
+                var layer = (gs as Component)?.gameObject.layer ?? 0;
+                if (camera && (camera.cullingMask & (1 << layer)) == 0) continue;
+                gs.RenderColor(cmd, camera);
+            }
+        }
+#endif
 
         // Called by GsplatPlayerLoopHook once per frame, before Unity's PostLateUpdate phase
         public void Update()

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -165,6 +165,12 @@ namespace Gsplat
                 return false;
             }
 
+            // A single global draw can only have one Unity layer. Mixed-layer sets must retain
+            // per-renderer draws so each camera's culling mask is respected.
+            var renderLayer = (m_activeGsplats[0] as Component)?.gameObject.layer ?? 0;
+            if (m_activeGsplats.Any(gs => ((gs as Component)?.gameObject.layer ?? 0) != renderLayer))
+                return false;
+
             return true;
         }
 

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -244,15 +244,22 @@ namespace Gsplat
         // Called by GsplatPlayerLoopHook once per frame, before Unity's PostLateUpdate phase
         public void Update()
         {
-            GlobalRenderEnabled = m_globalRenderer.Valid && GsplatSettings.Instance.EnableGlobalSort &&
-                                  m_activeGsplats.Count >= 2;
-            if (!GlobalRenderEnabled) return;
             m_activeGsplats.Clear();
             foreach (var gs in m_gsplats.Where(gs => gs is { isActiveAndEnabled: true, Valid: true }))
                 m_activeGsplats.Add(gs);
-            GlobalRenderEnabled = GlobalRenderEnabled && CanRenderGlobally();
-            if (!GlobalRenderEnabled) return;
-            m_globalRenderer.Update(m_activeGsplats);
+
+            GlobalRenderEnabled = m_globalRenderer.Valid && GsplatSettings.Instance.EnableGlobalSort &&
+                                  m_activeGsplats.Count >= 2 && CanRenderGlobally();
+            if (GlobalRenderEnabled)
+            {
+                m_globalRenderer.Update(m_activeGsplats);
+                return;
+            }
+
+            // Select and submit the fallback path here as well, so a runtime transition cannot
+            // make GsplatRenderer.Update observe the previous frame's global-render state.
+            foreach (var renderer in m_activeGsplats.OfType<GsplatRenderer>())
+                renderer.Render();
         }
 
         public ISorterResource CreateSorterResource(uint count, GraphicsBuffer orderBuffer)

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -269,7 +269,7 @@ namespace Gsplat
                 return;
             }
 
-            foreach (var gs in m_activeGsplats)
+            foreach (var gs in m_activeGsplats.OrderBy(gs => (gs as GsplatRenderer)?.RenderOrder ?? 0))
             {
                 if (gs.RemainingCount <= 0) continue;
                 var layer = (gs as Component)?.gameObject.layer ?? 0;
@@ -304,7 +304,7 @@ namespace Gsplat
                 return;
             }
 
-            foreach (var gs in m_activeGsplats)
+            foreach (var gs in m_activeGsplats.OrderBy(gs => (gs as GsplatRenderer)?.RenderOrder ?? 0))
             {
                 if (gs.RemainingCount <= 0) continue;
                 var layer = (gs as Component)?.gameObject.layer ?? 0;

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -174,7 +174,21 @@ namespace Gsplat
                 return false;
             }
 
+            // One merged draw cannot represent multiple Unity layers. Use per-renderer draws
+            // for mixed layers so each camera can apply its culling mask independently.
+            var renderLayer = m_activeGsplats[0].transform.gameObject.layer;
+            if (m_activeGsplats.Any(gs => gs.transform.gameObject.layer != renderLayer))
+                return false;
+
             return true;
+        }
+
+        bool CameraRendersGlobalLayer(Camera camera)
+        {
+            if (!camera)
+                return true;
+            var layer = m_activeGsplats[0].transform.gameObject.layer;
+            return (camera.cullingMask & (1 << layer)) != 0;
         }
 
         public void MarkGlobalBuffersDirty() => m_globalRenderer.MarkGlobalBuffersDirty();
@@ -248,14 +262,15 @@ namespace Gsplat
         {
             if (GlobalRenderEnabled)
             {
-                m_globalRenderer.RenderDepthPrepass(cmd);
+                if (CameraRendersGlobalLayer(camera))
+                    m_globalRenderer.RenderDepthPrepass(cmd);
                 return;
             }
 
             foreach (var gs in m_activeGsplats)
             {
                 if (gs.RemainingCount <= 0) continue;
-                var layer = (gs as Component)?.gameObject.layer ?? 0;
+                var layer = gs.transform.gameObject.layer;
                 if (camera && (camera.cullingMask & (1 << layer)) == 0) continue;
                 gs.RenderDepthPrepass(cmd, camera);
             }
@@ -265,14 +280,15 @@ namespace Gsplat
         {
             if (GlobalRenderEnabled)
             {
-                m_globalRenderer.RenderColor(cmd);
+                if (CameraRendersGlobalLayer(camera))
+                    m_globalRenderer.RenderColor(cmd);
                 return;
             }
 
             foreach (var gs in m_activeGsplats.OrderBy(gs => (gs as GsplatRenderer)?.RenderOrder ?? 0))
             {
                 if (gs.RemainingCount <= 0) continue;
-                var layer = (gs as Component)?.gameObject.layer ?? 0;
+                var layer = gs.transform.gameObject.layer;
                 if (camera && (camera.cullingMask & (1 << layer)) == 0) continue;
                 gs.RenderColor(cmd, camera);
             }
@@ -283,14 +299,15 @@ namespace Gsplat
         {
             if (GlobalRenderEnabled)
             {
-                m_globalRenderer.RenderDepthPrepass(cmd);
+                if (CameraRendersGlobalLayer(camera))
+                    m_globalRenderer.RenderDepthPrepass(cmd);
                 return;
             }
 
             foreach (var gs in m_activeGsplats)
             {
                 if (gs.RemainingCount <= 0) continue;
-                var layer = (gs as Component)?.gameObject.layer ?? 0;
+                var layer = gs.transform.gameObject.layer;
                 if (camera && (camera.cullingMask & (1 << layer)) == 0) continue;
                 gs.RenderDepthPrepass(cmd, camera);
             }
@@ -300,14 +317,15 @@ namespace Gsplat
         {
             if (GlobalRenderEnabled)
             {
-                m_globalRenderer.RenderColor(cmd);
+                if (CameraRendersGlobalLayer(camera))
+                    m_globalRenderer.RenderColor(cmd);
                 return;
             }
 
             foreach (var gs in m_activeGsplats.OrderBy(gs => (gs as GsplatRenderer)?.RenderOrder ?? 0))
             {
                 if (gs.RemainingCount <= 0) continue;
-                var layer = (gs as Component)?.gameObject.layer ?? 0;
+                var layer = gs.transform.gameObject.layer;
                 if (camera && (camera.cullingMask & (1 << layer)) == 0) continue;
                 gs.RenderColor(cmd, camera);
             }

--- a/Runtime/Materials/GsplatGlobal.asset
+++ b/Runtime/Materials/GsplatGlobal.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: GsplatGlobal
   m_EditorClassIdentifier:
   DefaultMaterial: {fileID: 2100000, guid: e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8, type: 2}
+  DefaultDepthMaterial: {fileID: 2100000, guid: 4d8e9f104a5b6c7d8e1f0a9b6c5d4e3f, type: 2}
   MergeShader: {fileID: 7200000, guid: a1e5c8f2b4d7903e6f2a8c1d5e9b3f70, type: 3}
   CopyBufferShader: {fileID: 7200000, guid: 3f7a1c4e8b2d9f506e1a4c7d3b8f2e90, type: 3}

--- a/Runtime/Materials/GsplatGlobalDepth.mat
+++ b/Runtime/Materials/GsplatGlobalDepth.mat
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GsplatGlobalDepth
+  m_Shader: {fileID: 4800000, guid: 9a5c8e1f2b3d4706a4f9c0d1e2b3a456, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - SH_BANDS_3
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats: []
+    m_Colors: []
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Runtime/Materials/GsplatGlobalDepth.mat.meta
+++ b/Runtime/Materials/GsplatGlobalDepth.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d8e9f104a5b6c7d8e1f0a9b6c5d4e3f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Materials/GsplatSpark.asset
+++ b/Runtime/Materials/GsplatSpark.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: GsplatSpark
   m_EditorClassIdentifier: 
   DefaultMaterial: {fileID: 2100000, guid: 0fd25878460c14a46946f5bffc5ee42f, type: 2}
+  DefaultDepthMaterial: {fileID: 2100000, guid: 3c7d8e9f104a5b6c8d2e1f0a9b6c5d4e, type: 2}
   CalcDepthShader: {fileID: 7200000, guid: f234fe86176948548be7fad55f5d6147, type: 3}
   InitOrderShader: {fileID: 7200000, guid: 9f8e041cb7bfae141b2e6ee80402bf45, type: 3}

--- a/Runtime/Materials/GsplatSparkDepth.mat
+++ b/Runtime/Materials/GsplatSparkDepth.mat
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GsplatSparkDepth
+  m_Shader: {fileID: 4800000, guid: 8f4d7a3b9c2e4615a0b1c6d8e9f20314, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - SH_BANDS_0
+  - SPARK
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats: []
+    m_Colors: []
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Runtime/Materials/GsplatSparkDepth.mat.meta
+++ b/Runtime/Materials/GsplatSparkDepth.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c7d8e9f104a5b6c8d2e1f0a9b6c5d4e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Materials/GsplatUncompressed.asset
+++ b/Runtime/Materials/GsplatUncompressed.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: GsplatUncompressed
   m_EditorClassIdentifier: 
   DefaultMaterial: {fileID: 2100000, guid: 0065a348838e5474f802212446cf1ddd, type: 2}
+  DefaultDepthMaterial: {fileID: 2100000, guid: 2b6c7d8e9f104a5b8c3d2e1f0a9b6c5d, type: 2}
   CalcDepthShader: {fileID: 7200000, guid: 03396f0af8c54a3093503c0c27511df3, type: 3}
   InitOrderShader: {fileID: 7200000, guid: 71f302cf0e7c6254e9bae3e5c94b77d6, type: 3}

--- a/Runtime/Materials/GsplatUncompressedDepth.mat
+++ b/Runtime/Materials/GsplatUncompressedDepth.mat
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GsplatUncompressedDepth
+  m_Shader: {fileID: 4800000, guid: 8f4d7a3b9c2e4615a0b1c6d8e9f20314, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - SH_BANDS_0
+  - UNCOMPRESSED
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats: []
+    m_Colors: []
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Runtime/Materials/GsplatUncompressedDepth.mat.meta
+++ b/Runtime/Materials/GsplatUncompressedDepth.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b6c7d8e9f104a5b8c3d2e1f0a9b6c5d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SRP/GsplatHDRPPass.cs
+++ b/Runtime/SRP/GsplatHDRPPass.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #if GSPLAT_ENABLE_HDRP
+using UnityEngine.Rendering;
 using UnityEngine.Rendering.HighDefinition;
 
 namespace Gsplat
@@ -13,6 +14,8 @@ namespace Gsplat
             if (GsplatSorter.Instance.Valid && GsplatSettings.Instance.Valid && GsplatSorter.Instance.GatherGsplatsForCamera(ctx.hdCamera.camera))
             {
                 GsplatSorter.Instance.DispatchSort(ctx.cmd, ctx.hdCamera.camera);
+                CoreUtils.SetRenderTarget(ctx.cmd, ctx.cameraColorBuffer, ctx.cameraDepthBuffer);
+                GsplatSorter.Instance.RenderDepthPrepass(ctx.cmd, ctx.hdCamera.camera);
                 GsplatSorter.Instance.RenderColor(ctx.cmd, ctx.hdCamera.camera);
             }
         }

--- a/Runtime/SRP/GsplatHDRPPass.cs
+++ b/Runtime/SRP/GsplatHDRPPass.cs
@@ -11,7 +11,10 @@ namespace Gsplat
         protected override void Execute(CustomPassContext ctx)
         {
             if (GsplatSorter.Instance.Valid && GsplatSettings.Instance.Valid && GsplatSorter.Instance.GatherGsplatsForCamera(ctx.hdCamera.camera))
+            {
                 GsplatSorter.Instance.DispatchSort(ctx.cmd, ctx.hdCamera.camera);
+                GsplatSorter.Instance.RenderColor(ctx.cmd, ctx.hdCamera.camera);
+            }
         }
     }
 }

--- a/Runtime/SRP/GsplatURPFeature.cs
+++ b/Runtime/SRP/GsplatURPFeature.cs
@@ -117,19 +117,19 @@ namespace Gsplat
 
         public override void Create()
         {
-            // Record all splat work before URP's transparent draw pass. The depth pass must run
-            // before color so its writes can also depth-test the transparents that follow.
+            // Record all splat work before URP's transparent draw pass. Render splat color before
+            // splat depth so overlapping transparent splats can blend before the depth write.
             m_pass = new GsplatRenderPass
             {
                 renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents - 3)
             };
             m_depthPrepass = new GsplatDepthPrepass
             {
-                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents - 2)
+                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents - 1)
             };
             m_colorPass = new GsplatColorPass
             {
-                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents - 1)
+                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents - 2)
             };
         }
 

--- a/Runtime/SRP/GsplatURPFeature.cs
+++ b/Runtime/SRP/GsplatURPFeature.cs
@@ -46,12 +46,86 @@ namespace Gsplat
 #endif
         }
 
+        class GsplatDepthPrepass : ScriptableRenderPass
+        {
+#if UNITY_6000_0_OR_NEWER
+            class PassData
+            {
+                public UniversalCameraData CameraData;
+            }
+
+            public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+            {
+                UniversalResourceData resourceData = frameData.Get<UniversalResourceData>();
+                using var builder = renderGraph.AddRasterRenderPass<PassData>("Gsplat.DepthPrepass",
+                    out PassData passData);
+                passData.CameraData = frameData.Get<UniversalCameraData>();
+                builder.SetRenderAttachmentDepth(resourceData.activeDepthTexture, AccessFlags.ReadWrite);
+                builder.AllowPassCulling(false);
+                builder.SetRenderFunc(static (PassData data, RasterGraphContext context) =>
+                {
+                    GsplatSorter.Instance.RenderDepthPrepass(context.cmd, data.CameraData.camera);
+                });
+            }
+#else
+            public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+            {
+                var cmd = CommandBufferPool.Get("Gsplat.DepthPrepass");
+                GsplatSorter.Instance.RenderDepthPrepass(cmd, renderingData.cameraData.camera);
+                context.ExecuteCommandBuffer(cmd);
+                CommandBufferPool.Release(cmd);
+            }
+#endif
+        }
+
+        class GsplatColorPass : ScriptableRenderPass
+        {
+#if UNITY_6000_0_OR_NEWER
+            class PassData
+            {
+                public UniversalCameraData CameraData;
+            }
+
+            public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+            {
+                UniversalResourceData resourceData = frameData.Get<UniversalResourceData>();
+                using var builder = renderGraph.AddRasterRenderPass<PassData>("Gsplat.Color", out PassData passData);
+                passData.CameraData = frameData.Get<UniversalCameraData>();
+                builder.SetRenderAttachment(resourceData.activeColorTexture, 0, AccessFlags.ReadWrite);
+                builder.SetRenderAttachmentDepth(resourceData.activeDepthTexture, AccessFlags.Read);
+                builder.AllowPassCulling(false);
+                builder.SetRenderFunc(static (PassData data, RasterGraphContext context) =>
+                {
+                    GsplatSorter.Instance.RenderColor(context.cmd, data.CameraData.camera);
+                });
+            }
+#else
+            public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+            {
+                var cmd = CommandBufferPool.Get("Gsplat.Color");
+                GsplatSorter.Instance.RenderColor(cmd, renderingData.cameraData.camera);
+                context.ExecuteCommandBuffer(cmd);
+                CommandBufferPool.Release(cmd);
+            }
+#endif
+        }
+
         GsplatRenderPass m_pass;
+        GsplatColorPass m_colorPass;
+        GsplatDepthPrepass m_depthPrepass;
         bool m_hasGsplats;
 
         public override void Create()
         {
             m_pass = new GsplatRenderPass { renderPassEvent = RenderPassEvent.BeforeRenderingTransparents };
+            m_colorPass = new GsplatColorPass
+            {
+                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents + 1)
+            };
+            m_depthPrepass = new GsplatDepthPrepass
+            {
+                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents + 2)
+            };
         }
 
         public override void OnCameraPreCull(ScriptableRenderer renderer, in CameraData cameraData)
@@ -66,7 +140,11 @@ namespace Gsplat
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
         {
             if (GsplatSorter.Instance.Valid && GsplatSettings.Instance.Valid && m_hasGsplats)
+            {
                 renderer.EnqueuePass(m_pass);
+                renderer.EnqueuePass(m_colorPass);
+                renderer.EnqueuePass(m_depthPrepass);
+            }
         }
 
         protected override void Dispose(bool disposing)
@@ -76,6 +154,8 @@ namespace Gsplat
             m_pass.CommandBuffer = null;
 #endif
             m_pass = null;
+            m_colorPass = null;
+            m_depthPrepass = null;
         }
     }
 }

--- a/Runtime/SRP/GsplatURPFeature.cs
+++ b/Runtime/SRP/GsplatURPFeature.cs
@@ -117,14 +117,19 @@ namespace Gsplat
 
         public override void Create()
         {
-            m_pass = new GsplatRenderPass { renderPassEvent = RenderPassEvent.BeforeRenderingTransparents };
-            m_colorPass = new GsplatColorPass
+            // Record all splat work before URP's transparent draw pass. The depth pass must run
+            // before color so its writes can also depth-test the transparents that follow.
+            m_pass = new GsplatRenderPass
             {
-                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents + 1)
+                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents - 3)
             };
             m_depthPrepass = new GsplatDepthPrepass
             {
-                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents + 2)
+                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents - 2)
+            };
+            m_colorPass = new GsplatColorPass
+            {
+                renderPassEvent = (RenderPassEvent)((int)RenderPassEvent.BeforeRenderingTransparents - 1)
             };
         }
 

--- a/Runtime/Shaders/Gsplat.shader
+++ b/Runtime/Shaders/Gsplat.shader
@@ -14,6 +14,113 @@ Shader "Gsplat/Standard"
 
         Pass
         {
+            Name "DepthPrepass"
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma require compute
+            #pragma multi_compile SH_BANDS_0 SH_BANDS_1 SH_BANDS_2 SH_BANDS_3 SH_BANDS_4
+            #pragma multi_compile UNCOMPRESSED SPARK
+
+            #include "UnityCG.cginc"
+            #include "Gsplat.hlsl"
+            #ifdef UNCOMPRESSED
+            #include "GsplatUncompressed.hlsl"
+            #endif
+            #ifdef SPARK
+            #include "GsplatSpark.hlsl"
+            #endif
+
+            int _SplatCount;
+            int _SplatInstanceSize;
+            float4x4 _MATRIX_M;
+            float _ScaleFactor;
+            float _DepthPrepassAlphaCutoff;
+            StructuredBuffer<uint> _OrderBuffer;
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                #if !defined(UNITY_INSTANCING_ENABLED) && !defined(UNITY_PROCEDURAL_INSTANCING_ENABLED) && !defined(UNITY_STEREO_INSTANCING_ENABLED)
+                uint instanceID : SV_InstanceID;
+                #endif
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            bool InitSource(appdata v, out SplatSource source)
+            {
+                #if !defined(UNITY_INSTANCING_ENABLED) && !defined(UNITY_PROCEDURAL_INSTANCING_ENABLED) && !defined(UNITY_STEREO_INSTANCING_ENABLED)
+                source.order = v.instanceID * _SplatInstanceSize + asuint(v.vertex.z);
+                #else
+                source.order = unity_InstanceID * _SplatInstanceSize + asuint(v.vertex.z);
+                #endif
+
+                if (source.order >= _SplatCount)
+                    return false;
+
+                source.id = _OrderBuffer[source.order];
+                source.cornerUV = float2(v.vertex.x, v.vertex.y) * _ScaleFactor;
+                return true;
+            }
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float alpha : TEXCOORD1;
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = discardVec;
+
+                SplatSource source;
+                if (!InitSource(v, source))
+                    return o;
+
+                SplatCenter center;
+                SplatCorner corner;
+                float4 color;
+                if (!InitSplatData(source, mul(UNITY_MATRIX_V, _MATRIX_M), center, corner, color))
+                    return o;
+
+                ClipCorner(corner, color.w);
+
+                o.vertex = center.proj + float4(corner.offset.x, _ProjectionParams.x * corner.offset.y, 0, 0);
+                o.alpha = color.a;
+                o.uv = corner.uv;
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float A = dot(i.uv, i.uv);
+                if (A > 1.0) discard;
+
+                float2 absUV = abs(i.uv);
+                float maxUV = max(absUV.x, absUV.y);
+
+                float falloff = -exp((maxUV - _ScaleFactor * 1.16) * 25 * _ScaleFactor);
+                float alpha = (exp(-A * 4.0) + falloff) * i.alpha;
+
+                if (alpha < _DepthPrepassAlphaCutoff) discard;
+                return 0;
+            }
+            ENDHLSL
+        }
+
+        Pass
+        {
             ZWrite Off
             Blend One OneMinusSrcAlpha
             Cull Off

--- a/Runtime/Shaders/GsplatDepth.shader
+++ b/Runtime/Shaders/GsplatDepth.shader
@@ -1,7 +1,7 @@
-// Copyright (c) 2025 Yize Wu
+// Copyright (c) 2026 Keir Rice
 // SPDX-License-Identifier: MIT
 
-Shader "Gsplat/Standard"
+Shader "Gsplat/DepthOnly"
 {
     Properties {}
     SubShader
@@ -14,8 +14,9 @@ Shader "Gsplat/Standard"
 
         Pass
         {
-            ZWrite Off
-            Blend One OneMinusSrcAlpha
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
             Cull Off
 
             HLSLPROGRAM
@@ -34,14 +35,11 @@ Shader "Gsplat/Standard"
             #include "GsplatSpark.hlsl"
             #endif
 
-
-            bool _GammaToLinear;
             int _SplatCount;
             int _SplatInstanceSize;
-            int _SHDegree;
             float4x4 _MATRIX_M;
-            float _Brightness;
             float _ScaleFactor;
+            float _DepthPrepassAlphaCutoff;
             StructuredBuffer<uint> _OrderBuffer;
 
             struct appdata
@@ -72,8 +70,8 @@ Shader "Gsplat/Standard"
             struct v2f
             {
                 float2 uv : TEXCOORD0;
+                float alpha : TEXCOORD1;
                 float4 vertex : SV_POSITION;
-                float4 color: COLOR;
                 UNITY_VERTEX_OUTPUT_STEREO
             };
 
@@ -95,18 +93,10 @@ Shader "Gsplat/Standard"
                 if (!InitSplatData(source, mul(UNITY_MATRIX_V, _MATRIX_M), center, corner, color))
                     return o;
 
-                #ifndef SH_BANDS_0
-                // calculate the model-space view direction
-                float3 dir = normalize(mul(center.view, (float3x3)center.modelView));
-                float3 sh[SH_COEFFS];
-                InitSH(source.id, sh);
-                color.rgb += EvalSH(sh, dir, _SHDegree);
-                #endif
-
                 ClipCorner(corner, color.w);
 
                 o.vertex = center.proj + float4(corner.offset.x, _ProjectionParams.x * corner.offset.y, 0, 0);
-                o.color = color;
+                o.alpha = color.a;
                 o.uv = corner.uv;
                 return o;
             }
@@ -120,16 +110,12 @@ Shader "Gsplat/Standard"
                 float maxUV = max(absUV.x, absUV.y);
 
                 float falloff = -exp((maxUV - _ScaleFactor * 1.16) * 25 * _ScaleFactor);
-                float alpha = (exp(-A * 4.0) + falloff) * i.color.a;
+                float alpha = (exp(-A * 4.0) + falloff) * i.alpha;
 
-                if (alpha < 1.0 / 255.0) discard;
-                if (_GammaToLinear)
-                    return float4(GammaToLinearSpace(i.color.rgb) * alpha * _Brightness, alpha);
-                return float4(i.color.rgb * alpha * _Brightness, alpha);
+                if (alpha < _DepthPrepassAlphaCutoff) discard;
+                return 0;
             }
             ENDHLSL
-
-
         }
     }
 }

--- a/Runtime/Shaders/GsplatDepth.shader.meta
+++ b/Runtime/Shaders/GsplatDepth.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8f4d7a3b9c2e4615a0b1c6d8e9f20314
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shaders/GsplatGlobal.shader
+++ b/Runtime/Shaders/GsplatGlobal.shader
@@ -19,6 +19,97 @@ Shader "Gsplat/Global"
 
         Pass
         {
+            Name "DepthPrepass"
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma require compute
+            #pragma multi_compile SH_BANDS_0 SH_BANDS_1 SH_BANDS_2 SH_BANDS_3 SH_BANDS_4
+
+            #include "UnityCG.cginc"
+
+            int _SplatInstanceSize;
+            float _DepthPrepassAlphaCutoff;
+
+            #include "GsplatSparkGlobal.hlsl"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                #if !defined(UNITY_INSTANCING_ENABLED) && !defined(UNITY_PROCEDURAL_INSTANCING_ENABLED) && !defined(UNITY_STEREO_INSTANCING_ENABLED)
+                uint instanceID : SV_InstanceID;
+                #endif
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                nointerpolation uint rendererId : TEXCOORD1;
+                float alpha : TEXCOORD2;
+                float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_OUTPUT(v2f, o);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = discardVec;
+
+                #if !defined(UNITY_INSTANCING_ENABLED) && !defined(UNITY_PROCEDURAL_INSTANCING_ENABLED) && !defined(UNITY_STEREO_INSTANCING_ENABLED)
+                uint instanceId = v.instanceID;
+                #else
+                uint instanceId = unity_InstanceID;
+                #endif
+
+                GlobalSplatSource source;
+                if (!InitGlobalSource(instanceId, v.vertex.xyz, source))
+                    return o;
+
+                SplatCenter center;
+                SplatCorner corner;
+                float4 color;
+                if (!InitGlobalSplatData(source, center, corner, color))
+                    return o;
+
+                ClipCorner(corner, color.a);
+
+                o.vertex = center.proj + float4(corner.offset.x, _ProjectionParams.x * corner.offset.y, 0, 0);
+                o.alpha = color.a;
+                o.uv = corner.uv;
+                o.rendererId = source.rendererId;
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                RendererParams p = _RendererParams[i.rendererId];
+
+                float A = dot(i.uv, i.uv);
+                if (A > 1.0) discard;
+
+                float2 absUV = abs(i.uv);
+                float maxUV = max(absUV.x, absUV.y);
+
+                float falloff = -exp((maxUV - p.scaleFactor * 1.16) * 25 * p.scaleFactor);
+                float alpha = (exp(-A * 4.0) + falloff) * i.alpha;
+
+                if (alpha < _DepthPrepassAlphaCutoff) discard;
+                return 0;
+            }
+            ENDHLSL
+        }
+
+        Pass
+        {
             ZWrite Off
             Blend One OneMinusSrcAlpha
             Cull Off

--- a/Runtime/Shaders/GsplatGlobalDepth.shader
+++ b/Runtime/Shaders/GsplatGlobalDepth.shader
@@ -1,12 +1,7 @@
 // Copyright (c) 2026 Keir Rice
 // SPDX-License-Identifier: MIT
-//
-// Unified draw shader for global K-way merged Gaussian splatting.
-// Reads from concatenated global buffers (GlobalPackedBuffer, GlobalSH*Buffers)
-// via indices from GlobalOrderBuffer. Per-renderer transforms applied via
-// RendererTransforms structured buffer.
 
-Shader "Gsplat/Global"
+Shader "Gsplat/GlobalDepthOnly"
 {
     Properties {}
     SubShader
@@ -19,8 +14,9 @@ Shader "Gsplat/Global"
 
         Pass
         {
-            ZWrite Off
-            Blend One OneMinusSrcAlpha
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
             Cull Off
 
             HLSLPROGRAM
@@ -32,6 +28,7 @@ Shader "Gsplat/Global"
             #include "UnityCG.cginc"
 
             int _SplatInstanceSize;
+            float _DepthPrepassAlphaCutoff;
 
             #include "GsplatSparkGlobal.hlsl"
 
@@ -48,8 +45,8 @@ Shader "Gsplat/Global"
             {
                 float2 uv : TEXCOORD0;
                 nointerpolation uint rendererId : TEXCOORD1;
+                float alpha : TEXCOORD2;
                 float4 vertex : SV_POSITION;
-                float4 color : COLOR;
                 UNITY_VERTEX_OUTPUT_STEREO
             };
 
@@ -77,19 +74,11 @@ Shader "Gsplat/Global"
                 if (!InitGlobalSplatData(source, center, corner, color))
                     return o;
 
-                #ifndef SH_BANDS_0
-                // center.modelView is already computed by InitGlobalSplatData → InitCenter.
-                float3 dir = normalize(mul(center.view, (float3x3)center.modelView));
-                float3 sh[SH_COEFFS];
-                InitGlobalSH(source, sh);
-                color.rgb += EvalSH(sh, dir, (int)_RendererParams[source.rendererId].shDegree);
-                #endif
-
                 ClipCorner(corner, color.a);
 
                 o.vertex = center.proj + float4(corner.offset.x, _ProjectionParams.x * corner.offset.y, 0, 0);
-                o.color  = color;
-                o.uv     = corner.uv;
+                o.alpha = color.a;
+                o.uv = corner.uv;
                 o.rendererId = source.rendererId;
                 return o;
             }
@@ -105,12 +94,10 @@ Shader "Gsplat/Global"
                 float maxUV = max(absUV.x, absUV.y);
 
                 float falloff = -exp((maxUV - p.scaleFactor * 1.16) * 25 * p.scaleFactor);
-                float alpha = (exp(-A * 4.0) + falloff) * i.color.a;
+                float alpha = (exp(-A * 4.0) + falloff) * i.alpha;
 
-                if (alpha < 1.0 / 255.0) discard;
-                if (p.gammaToLinear)
-                    return float4(GammaToLinearSpace(i.color.rgb) * alpha * p.brightness, alpha);
-                return float4(i.color.rgb * alpha * p.brightness, alpha);
+                if (alpha < _DepthPrepassAlphaCutoff) discard;
+                return 0;
             }
             ENDHLSL
         }

--- a/Runtime/Shaders/GsplatGlobalDepth.shader.meta
+++ b/Runtime/Shaders/GsplatGlobalDepth.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9a5c8e1f2b3d4706a4f9c0d1e2b3a456
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Shaders/GsplatMergeOrderBuffers.compute
+++ b/Runtime/Shaders/GsplatMergeOrderBuffers.compute
@@ -109,7 +109,10 @@ void MergeTwo(uint3 id : SV_DispatchThreadID)
     float dA = (i < _CountA) ? _DepthsA[_OffsetA + i] : FLOAT_MAX;
     float dB = (j < _CountB) ? _DepthsB[_OffsetB + j] : FLOAT_MAX;
 
-    _OutputOrders[_OutputOffset + p] = (dA <= dB) ? _OrdersA[_OffsetA + i] : _OrdersB[_OffsetB + j];
+    if (dA <= dB)
+        _OutputOrders[_OutputOffset + p] = _OrdersA[_OffsetA + i];
+    else
+        _OutputOrders[_OutputOffset + p] = _OrdersB[_OffsetB + j];
 }
 
 // Intermediate merge pass — writes merged orders AND depths to scratch.


### PR DESCRIPTION
This PR adds an optional alpha-tested depth prepass for Gaussian splats. The prepass
allows opaque scene geometry and sufficiently opaque splat regions to participate in
depth compositing while retaining the normal transparent color pass.

A new `Depth Prepass Alpha Cutoff` project setting controls which splat fragments
write depth. Its default value is `1.1`, which disables depth writes and preserves
the existing rendering behavior until the feature is explicitly enabled.

The change also moves URP color drawing into explicit renderer-feature passes. It
supports both the legacy command-buffer path and the Unity 6 Render Graph path.
HDRP's custom pass explicitly sorts and renders the color pass so HDRP rendering is
not suppressed by the SRP-specific draw path.

### Main changes

- Add `GsplatSettings.DepthPrepassAlphaCutoff` with a project-settings field.
- Add depth-only shaders and materials for:
  - Spark-compressed splats
  - Uncompressed splats
  - Globally merged splats
- Add cached depth-material variants for SH bands and render orders.
- Add per-renderer and global depth-draw methods.
- Add explicit color and depth passes to the URP renderer feature.
- Support both `CommandBuffer` and Unity 6 `RasterCommandBuffer` rendering.
- Make the HDRP custom pass issue the color draw after sorting.
- Preserve the built-in render-pipeline draw path.
- Apply camera culling masks to per-renderer SRP draws.

### Behavior

- A cutoff greater than `1.0` disables the depth prepass.
- Lower cutoff values allow more splat fragments to write depth.
- The normal color pass still performs splat blending.
- Global sorting uses a matching global depth material when enabled.

### Risk and compatibility

This PR touches the built-in, URP, and HDRP rendering paths and has the widest
rendering impact of the extracted branches. The default setting is intended to keep
depth writes disabled, but the explicit SRP color path is still a structural change.

This branch currently contains Unity-generated material and `.meta` lines with
trailing spaces. Those lines came from the original assets and may be normalized
separately if required by the upstream repository's formatting policy.

### Suggested testing

- Verify splats render with the default cutoff in built-in, URP, and HDRP projects.
- Test Spark and Uncompressed assets.
- Test global sorting both enabled and disabled.
- Enable the depth prepass and verify occlusion against opaque scene geometry.
- Test several cutoff values, including `0`, a mid-range value, `1`, and the disabled
  default of `1.1`.
- Verify Game, Scene, and additional cameras with differing culling masks.
- Test Unity 6 Render Graph and the pre-Unity-6 URP command-buffer path where supported.


