### PR TITLE
Fix invalid global-merge reads and respect camera layer masks

### DIFF
--- a/Runtime/GsplatGlobalRenderer.cs
+++ b/Runtime/GsplatGlobalRenderer.cs
@@ -57,6 +57,7 @@ namespace Gsplat
         Matrix4x4[] m_rendererTransformsCache;
         RendererParams[] m_rendererParamsCache;
         MaterialPropertyBlock m_globalPropertyBlock;
+        int m_renderLayer;
 
         public bool Valid => m_globalMaterial
                              && m_globalMaterial.Valid()
@@ -156,6 +157,7 @@ namespace Gsplat
         {
             EnsureGlobalBuffers(activeGsplats);
             if (m_totalSplatCount == 0) return;
+            m_renderLayer = (activeGsplats[0] as Component)?.gameObject.layer ?? 0;
             UpdateRendererTransforms(activeGsplats);
             UpdateRendererParams(activeGsplats);
             Render();
@@ -492,7 +494,8 @@ namespace Gsplat
             var rp = new RenderParams(m_globalMaterial.Materials[m_globalSHBands])
             {
                 worldBounds = new Bounds(Vector3.zero, Vector3.one * 1e6f),
-                matProps = m_globalPropertyBlock
+                matProps = m_globalPropertyBlock,
+                layer = m_renderLayer
             };
 
             int instances = Mathf.CeilToInt(m_totalRemainingCount / (float)GsplatSettings.Instance.SplatInstanceSize);

--- a/Runtime/GsplatGlobalRenderer.cs
+++ b/Runtime/GsplatGlobalRenderer.cs
@@ -157,7 +157,7 @@ namespace Gsplat
         {
             EnsureGlobalBuffers(activeGsplats);
             if (m_totalSplatCount == 0) return;
-            m_renderLayer = (activeGsplats[0] as Component)?.gameObject.layer ?? 0;
+            m_renderLayer = activeGsplats[0].transform.gameObject.layer;
             UpdateRendererTransforms(activeGsplats);
             UpdateRendererParams(activeGsplats);
             Render();

--- a/Runtime/GsplatRenderer.cs
+++ b/Runtime/GsplatRenderer.cs
@@ -163,12 +163,17 @@ namespace Gsplat
             {
                 m_renderer.EvaluateRefreshRequired(SortMode, SortRefreshRate - 1, CutoutsRefreshRate - 1);
                 m_renderer.DispatchInitOrder(Cutouts, transform.localToWorldMatrix, CutoutsUpdateBounds);
-                // When the global sorter has merged all renderers into a single draw call,
-                // skip the per-renderer draw — GsplatSorter.DrawAll handles rendering.
-                if (!GsplatSorter.Instance.GlobalRenderEnabled)
-                    m_renderer.Render(transform, gameObject.layer, GammaToLinear, SHDegree, Brightness,
-                        1.0f - SplatDownscaleFactor, RenderOrder);
             }
+        }
+
+        // Called by GsplatSorter after it has selected one render path for the frame.
+        internal void Render()
+        {
+            if (!Valid || !GsplatSettings.Instance.Valid || !GsplatSorter.Instance.Valid)
+                return;
+
+            m_renderer.Render(transform, gameObject.layer, GammaToLinear, SHDegree, Brightness,
+                1.0f - SplatDownscaleFactor, RenderOrder);
         }
     }
 }

--- a/Runtime/GsplatRenderer.cs
+++ b/Runtime/GsplatRenderer.cs
@@ -34,6 +34,24 @@ namespace Gsplat
         public bool AsyncUpload;
         public bool RenderBeforeUploadComplete = true;
 
+        [SerializeField]
+        [Tooltip("When enabled, this renderer can be merged with other compatible renderers for global depth sorting. Disable it for isolated previews or other renderers that must retain an independent draw.")]
+        bool m_participateInGlobalSort = true;
+
+        public bool ParticipateInGlobalSort
+        {
+            get => m_participateInGlobalSort;
+            set
+            {
+                if (m_participateInGlobalSort == value)
+                    return;
+
+                m_participateInGlobalSort = value;
+                if (isActiveAndEnabled)
+                    GsplatSorter.Instance.MarkGlobalBuffersDirty();
+            }
+        }
+
         [Tooltip("Does cutouts update the Gsplat world bounds? (Costly on moving cutouts)")]
         public bool CutoutsUpdateBounds = true;
 
@@ -123,6 +141,7 @@ namespace Gsplat
         void OnValidate()
         {
             ForceRefresh();
+            GsplatSorter.Instance.MarkGlobalBuffersDirty();
 #if UNITY_EDITOR
             if (GsplatAsset &&
                 AssetDatabase.TryGetGUIDAndLocalFileIdentifier(GsplatAsset, out var guid, out long localId))

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -167,8 +167,8 @@ namespace Gsplat
 
             // A single global draw can only have one Unity layer. Mixed-layer sets must retain
             // per-renderer draws so each camera's culling mask is respected.
-            var renderLayer = (m_activeGsplats[0] as Component)?.gameObject.layer ?? 0;
-            if (m_activeGsplats.Any(gs => ((gs as Component)?.gameObject.layer ?? 0) != renderLayer))
+            var renderLayer = m_activeGsplats[0].transform.gameObject.layer;
+            if (m_activeGsplats.Any(gs => gs.transform.gameObject.layer != renderLayer))
                 return false;
 
             return true;

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -165,6 +165,12 @@ namespace Gsplat
                 return false;
             }
 
+            // A single global draw can only have one Unity layer. Mixed-layer sets must retain
+            // per-renderer draws so each camera's culling mask is respected.
+            var renderLayer = (m_activeGsplats[0] as Component)?.gameObject.layer ?? 0;
+            if (m_activeGsplats.Any(gs => ((gs as Component)?.gameObject.layer ?? 0) != renderLayer))
+                return false;
+
             return true;
         }
 

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -244,15 +244,22 @@ namespace Gsplat
         // Called by GsplatPlayerLoopHook once per frame, before Unity's PostLateUpdate phase
         public void Update()
         {
-            GlobalRenderEnabled = m_globalRenderer.Valid && GsplatSettings.Instance.EnableGlobalSort &&
-                                  m_activeGsplats.Count >= 2;
-            if (!GlobalRenderEnabled) return;
             m_activeGsplats.Clear();
             foreach (var gs in m_gsplats.Where(gs => gs is { isActiveAndEnabled: true, Valid: true }))
                 m_activeGsplats.Add(gs);
-            GlobalRenderEnabled = GlobalRenderEnabled && CanRenderGlobally();
-            if (!GlobalRenderEnabled) return;
-            m_globalRenderer.Update(m_activeGsplats);
+
+            GlobalRenderEnabled = m_globalRenderer.Valid && GsplatSettings.Instance.EnableGlobalSort &&
+                                  m_activeGsplats.Count >= 2 && CanRenderGlobally();
+            if (GlobalRenderEnabled)
+            {
+                m_globalRenderer.Update(m_activeGsplats);
+                return;
+            }
+
+            // Select and submit the fallback path here as well, so a runtime transition cannot
+            // make GsplatRenderer.Update observe the previous frame's global-render state.
+            foreach (var renderer in m_activeGsplats.OfType<GsplatRenderer>())
+                renderer.Render();
         }
 
         public ISorterResource CreateSorterResource(uint count, GraphicsBuffer orderBuffer)

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -68,6 +68,8 @@ namespace Gsplat
         readonly HashSet<IGsplat> m_gsplats = new();
         readonly HashSet<Camera> m_camerasInjected = new();
         readonly List<IGsplat> m_activeGsplats = new();
+        readonly List<IGsplat> m_globalGsplats = new();
+        readonly List<IGsplat> m_fallbackGsplats = new();
         readonly HashSet<int> m_warnedUncompressed = new();
         GsplatSortPass m_sortPass;
         public const string k_passName = "SortGsplats";
@@ -124,6 +126,8 @@ namespace Gsplat
             }
 
             m_activeGsplats.Clear();
+            m_globalGsplats.Clear();
+            m_fallbackGsplats.Clear();
             m_commandBuffer?.Dispose();
             m_commandBuffer = null;
             Camera.onPreCull -= OnPreCullCamera;
@@ -146,7 +150,7 @@ namespace Gsplat
         bool CanRenderGlobally()
         {
             // renderer_id is packed into 8 bits ([31:24]); max 255 renderers.
-            if (m_activeGsplats.Count > 255)
+            if (m_globalGsplats.Count > 255)
             {
                 Debug.LogError(
                     "[GsplatSorter] Global merge supports at most 255 renderers. Falling back to per-renderer rendering.");
@@ -154,21 +158,21 @@ namespace Gsplat
             }
 
             // Global merge requires every active renderer to use SPARK compression.
-            foreach (var gs in m_activeGsplats)
+            foreach (var gs in m_globalGsplats)
             {
                 if (gs.GsplatResource is GsplatResourceSpark) continue;
                 var obj = gs as UnityEngine.Object;
                 var id = obj ? obj.GetInstanceID() : 0;
                 if (m_warnedUncompressed.Add(id))
                     Debug.LogWarning(
-                        $"[GsplatSorter] '{obj?.name}' uses an uncompressed asset; global sort requires every active renderer to use SPARK compression. Disabling global sort for this scene — all renderers fall back to per-renderer rendering.");
+                        $"[GsplatSorter] '{obj?.name}' uses an uncompressed asset; global sort requires every participating renderer to use SPARK compression. Participating renderers will fall back to per-renderer rendering.");
                 return false;
             }
 
             // A single global draw can only have one Unity layer. Mixed-layer sets must retain
             // per-renderer draws so each camera's culling mask is respected.
-            var renderLayer = m_activeGsplats[0].transform.gameObject.layer;
-            if (m_activeGsplats.Any(gs => gs.transform.gameObject.layer != renderLayer))
+            var renderLayer = m_globalGsplats[0].transform.gameObject.layer;
+            if (m_globalGsplats.Any(gs => gs.transform.gameObject.layer != renderLayer))
                 return false;
 
             return true;
@@ -238,7 +242,7 @@ namespace Gsplat
 
             // --- Global K-way merge ---
             if (GlobalRenderEnabled)
-                m_globalRenderer.DispatchMerge(cmd, m_activeGsplats);
+                m_globalRenderer.DispatchMerge(cmd, m_globalGsplats);
         }
 
         // Called by GsplatPlayerLoopHook once per frame, before Unity's PostLateUpdate phase
@@ -248,11 +252,23 @@ namespace Gsplat
             foreach (var gs in m_gsplats.Where(gs => gs is { isActiveAndEnabled: true, Valid: true }))
                 m_activeGsplats.Add(gs);
 
+            m_globalGsplats.Clear();
+            m_fallbackGsplats.Clear();
+            foreach (var gs in m_activeGsplats)
+            {
+                if (gs is GsplatRenderer { ParticipateInGlobalSort: false })
+                    m_fallbackGsplats.Add(gs);
+                else
+                    m_globalGsplats.Add(gs);
+            }
+
             GlobalRenderEnabled = m_globalRenderer.Valid && GsplatSettings.Instance.EnableGlobalSort &&
-                                  m_activeGsplats.Count >= 2 && CanRenderGlobally();
+                                  m_globalGsplats.Count >= 2 && CanRenderGlobally();
             if (GlobalRenderEnabled)
             {
-                m_globalRenderer.Update(m_activeGsplats);
+                m_globalRenderer.Update(m_globalGsplats);
+                foreach (var renderer in m_fallbackGsplats.OfType<GsplatRenderer>())
+                    renderer.Render();
                 return;
             }
 

--- a/Runtime/Shaders/GsplatMergeOrderBuffers.compute
+++ b/Runtime/Shaders/GsplatMergeOrderBuffers.compute
@@ -109,7 +109,10 @@ void MergeTwo(uint3 id : SV_DispatchThreadID)
     float dA = (i < _CountA) ? _DepthsA[_OffsetA + i] : FLOAT_MAX;
     float dB = (j < _CountB) ? _DepthsB[_OffsetB + j] : FLOAT_MAX;
 
-    _OutputOrders[_OutputOffset + p] = (dA <= dB) ? _OrdersA[_OffsetA + i] : _OrdersB[_OffsetB + j];
+    if (dA <= dB)
+        _OutputOrders[_OutputOffset + p] = _OrdersA[_OffsetA + i];
+    else
+        _OutputOrders[_OutputOffset + p] = _OrdersB[_OffsetB + j];
 }
 
 // Intermediate merge pass — writes merged orders AND depths to scratch.


### PR DESCRIPTION
This PR fixes correctness issues in globally sorted rendering.

First, the final merge shader previously used a conditional expression that could
evaluate an out-of-range buffer access before selecting the valid result. Replacing
it with an explicit branch ensures only the selected order buffer is read.

Second, one global draw can carry only one Unity layer. The global path now falls
back to per-renderer rendering when participating splat renderers use different
layers. If all participating renderers share a layer, that layer is assigned to the
global `RenderParams`, so Unity camera culling masks include or exclude the merged
draw correctly.

Third, isolated splat renderers such as model or panel previews can now opt out of
the global merge through `GsplatRenderer.ParticipateInGlobalSort`. Participating
same-layer scene renderers can remain globally sorted while opted-out renderers use
the existing per-renderer fallback path.

### Main changes

- Replace the final merge shader's conditional buffer read with an explicit branch.
- Detect mixed-layer participating renderer sets and disable global merging for that
  set.
- Store the shared participating renderer layer on the global renderer.
- Assign the shared layer to the global `RenderParams` draw.
- Add the serialized, runtime-settable `ParticipateInGlobalSort` renderer option,
  enabled by default.
- Partition active renderers into the global set and a per-renderer fallback set.
- Keep opted-out renderers visible while the participating set uses the global draw.

### Risk and compatibility

Existing renderers participate by default, so existing same-layer scenes retain the
global draw optimization.

Mixed layers within the participating set still force the scene back to
per-renderer rendering. A renderer explicitly opted out of global sorting is not
depth-sorted against the global set, so opt-out is intended for isolated previews,
UI, or renderers in a separate visual space. It should not be used for splats that
must blend with participating renderers in the same scene.

When global rendering is active, each opted-out renderer retains its existing
per-renderer sort and draw cost. The renderer partitions reuse their lists and do
not add per-frame managed allocations.

### Integration note with `pr/depth-prepass`

This branch is independently correct against current `main`, whose global draw uses
`RenderParams`. The depth-prepass branch adds SRP command-buffer global draws, which
do not receive layer filtering automatically. If both PRs are accepted, rebase this
branch after `pr/depth-prepass` and retain the combined branch's per-camera global
eligibility check and opted-out fallback draws in the new color and depth draw
methods. This prevents the SRP global path from reintroducing the camera-mask
regression or dropping opted-out renderers.

### Suggested testing

- Render two globally sorted splat objects on the same layer.
- Confirm a camera including that layer renders the global draw.
- Confirm a camera excluding that layer does not render the splats.
- Put two participating renderers on different layers and confirm the system falls
  back to per-renderer rendering.
- Render two participating same-layer scene splats plus one opted-out preview on a
  different layer; confirm the scene splats remain globally sorted and the preview
  remains visible.
- Confirm an opted-out renderer continues to use its per-renderer sorting path.
- Use separate cameras that include different renderer layers.
- Exercise merge inputs where either side of the final merge is exhausted first.

### Consumer validation

The opt-out path was tested in Open Brush with two dynamically imported,
overlapping scene splats and an active model preview on the Panels layer. The
imported scene splats remained in the global set while the preview rendered through
the independent fallback path.