### PR TITLE
Add GPU sphere intersection queries for Gaussian splats

### DIFF
--- a/Runtime/GsplatRenderer.cs
+++ b/Runtime/GsplatRenderer.cs
@@ -87,6 +87,16 @@ namespace Gsplat
 
         public void ComputeDepth(CommandBuffer cmd, Matrix4x4 matrixMv) => m_renderer.ComputeDepth(cmd, matrixMv);
 
+        public bool TryIntersectSphere(Vector3 centerWorld, float radiusWorld, out float score)
+        {
+            score = -1.0f;
+            if (!Valid || m_renderer == null)
+                return false;
+
+            return m_renderer.TryIntersectSphere(transform, centerWorld, radiusWorld,
+                1.0f - SplatDownscaleFactor, out score);
+        }
+
         void OnEnable()
         {
             GsplatSorter.Instance.RegisterGsplat(this);

--- a/Runtime/GsplatRendererImpl.cs
+++ b/Runtime/GsplatRendererImpl.cs
@@ -78,7 +78,7 @@ namespace Gsplat
         {
             score = -1.0f;
             ComputeShader cs = GsplatSettings.Instance.IntersectionShader;
-            if (!cs || GsplatResource == null || GsplatResource.UploadedCount == 0)
+            if (!cs || GsplatResource == null || GsplatResource.UploadedCount == 0 || m_remainingCount == 0)
                 return false;
 
             int kernel;
@@ -98,6 +98,8 @@ namespace Gsplat
                 return false;
             }
 
+            cs.SetBuffer(kernel, k_orderBuffer, SorterResource.OrderBuffer);
+
             EnsureIntersectionBuffer();
             m_intersectionHit[0] = 0;
             m_intersectionHitBuffer.SetData(m_intersectionHit);
@@ -110,12 +112,12 @@ namespace Gsplat
                     worldToLocal.MultiplyVector(Vector3.up * radiusWorld).magnitude,
                     worldToLocal.MultiplyVector(Vector3.forward * radiusWorld).magnitude));
 
-            cs.SetInt(k_splatCount, (int)GsplatResource.UploadedCount);
+            cs.SetInt(k_splatCount, (int)m_remainingCount);
             cs.SetVector(k_sphereCenter, centerLocal);
             cs.SetFloat(k_sphereRadius, radiusLocal);
             cs.SetFloat(k_scaleFactor, scaleFactor);
             cs.SetBuffer(kernel, k_hitBuffer, m_intersectionHitBuffer);
-            cs.Dispatch(kernel, (int)GsplatUtils.DivRoundUp(GsplatResource.UploadedCount, 256), 1, 1);
+            cs.Dispatch(kernel, (int)GsplatUtils.DivRoundUp(m_remainingCount, 256), 1, 1);
 
             m_intersectionHitBuffer.GetData(m_intersectionHit);
             if (m_intersectionHit[0] == 0)

--- a/Runtime/GsplatRendererImpl.cs
+++ b/Runtime/GsplatRendererImpl.cs
@@ -25,11 +25,19 @@ namespace Gsplat
         public GraphicsBuffer OrderSizeBuffer { get; private set; }
         public GraphicsBuffer BoundsBuffer { get; private set; }
         public ISorterResource SorterResource { get; private set; }
+        GraphicsBuffer m_intersectionHitBuffer;
+        readonly uint[] m_intersectionHit = new uint[1];
 
         static readonly int k_orderBuffer = Shader.PropertyToID("_OrderBuffer");
+        static readonly int k_packedSplatsBuffer = Shader.PropertyToID("_PackedSplatsBuffer");
+        static readonly int k_positionBuffer = Shader.PropertyToID("_PositionBuffer");
+        static readonly int k_scaleBuffer = Shader.PropertyToID("_ScaleBuffer");
         static readonly int k_matrixM = Shader.PropertyToID("_MATRIX_M");
         static readonly int k_splatInstanceSize = Shader.PropertyToID("_SplatInstanceSize");
         static readonly int k_splatCount = Shader.PropertyToID("_SplatCount");
+        static readonly int k_sphereCenter = Shader.PropertyToID("_SphereCenter");
+        static readonly int k_sphereRadius = Shader.PropertyToID("_SphereRadius");
+        static readonly int k_hitBuffer = Shader.PropertyToID("_HitBuffer");
         static readonly int k_gammaToLinear = Shader.PropertyToID("_GammaToLinear");
         static readonly int k_shDegree = Shader.PropertyToID("_SHDegree");
         static readonly int k_brightness = Shader.PropertyToID("_Brightness");
@@ -64,6 +72,63 @@ namespace Gsplat
 
         public void ComputeDepth(CommandBuffer cmd, Matrix4x4 matrixMv) =>
             m_gsplatAsset.ComputeDepth(cmd, matrixMv, SorterResource, GsplatResource);
+
+        public bool TryIntersectSphere(Transform transform, Vector3 centerWorld, float radiusWorld,
+            float scaleFactor, out float score)
+        {
+            score = -1.0f;
+            ComputeShader cs = GsplatSettings.Instance.IntersectionShader;
+            if (!cs || GsplatResource == null || GsplatResource.UploadedCount == 0)
+                return false;
+
+            int kernel;
+            if (GsplatResource is GsplatResourceSpark spark)
+            {
+                kernel = cs.FindKernel("IntersectSpark");
+                cs.SetBuffer(kernel, k_packedSplatsBuffer, spark.PackedSplatsBuffer);
+            }
+            else if (GsplatResource is GsplatResourceUncompressed uncompressed)
+            {
+                kernel = cs.FindKernel("IntersectUncompressed");
+                cs.SetBuffer(kernel, k_positionBuffer, uncompressed.PositionBuffer);
+                cs.SetBuffer(kernel, k_scaleBuffer, uncompressed.ScaleBuffer);
+            }
+            else
+            {
+                return false;
+            }
+
+            EnsureIntersectionBuffer();
+            m_intersectionHit[0] = 0;
+            m_intersectionHitBuffer.SetData(m_intersectionHit);
+
+            Matrix4x4 worldToLocal = transform.worldToLocalMatrix;
+            Vector3 centerLocal = worldToLocal.MultiplyPoint3x4(centerWorld);
+            float radiusLocal = Mathf.Max(
+                worldToLocal.MultiplyVector(Vector3.right * radiusWorld).magnitude,
+                Mathf.Max(
+                    worldToLocal.MultiplyVector(Vector3.up * radiusWorld).magnitude,
+                    worldToLocal.MultiplyVector(Vector3.forward * radiusWorld).magnitude));
+
+            cs.SetInt(k_splatCount, (int)GsplatResource.UploadedCount);
+            cs.SetVector(k_sphereCenter, centerLocal);
+            cs.SetFloat(k_sphereRadius, radiusLocal);
+            cs.SetFloat(k_scaleFactor, scaleFactor);
+            cs.SetBuffer(kernel, k_hitBuffer, m_intersectionHitBuffer);
+            cs.Dispatch(kernel, (int)GsplatUtils.DivRoundUp(GsplatResource.UploadedCount, 256), 1, 1);
+
+            m_intersectionHitBuffer.GetData(m_intersectionHit);
+            if (m_intersectionHit[0] == 0)
+                return false;
+
+            score = 1.0f;
+            return true;
+        }
+
+        void EnsureIntersectionBuffer()
+        {
+            m_intersectionHitBuffer ??= new GraphicsBuffer(GraphicsBuffer.Target.Structured, 1, sizeof(uint));
+        }
 
         Bounds ExtractBounds()
         {
@@ -181,6 +246,8 @@ namespace Gsplat
             OrderSizeBuffer = null;
             BoundsBuffer?.Dispose();
             BoundsBuffer = null;
+            m_intersectionHitBuffer?.Dispose();
+            m_intersectionHitBuffer = null;
         }
 
         public void ForceRefresh()

--- a/Runtime/GsplatRendererImpl.cs
+++ b/Runtime/GsplatRendererImpl.cs
@@ -38,6 +38,7 @@ namespace Gsplat
         static readonly int k_splatCount = Shader.PropertyToID("_SplatCount");
         static readonly int k_sphereCenter = Shader.PropertyToID("_SphereCenter");
         static readonly int k_sphereRadius = Shader.PropertyToID("_SphereRadius");
+        static readonly int k_maxObjectScale = Shader.PropertyToID("_MaxObjectScale");
         static readonly int k_hitBuffer = Shader.PropertyToID("_HitBuffer");
         static readonly int k_gammaToLinear = Shader.PropertyToID("_GammaToLinear");
         static readonly int k_shDegree = Shader.PropertyToID("_SHDegree");
@@ -106,18 +107,19 @@ namespace Gsplat
             m_intersectionHit[0] = 0;
             m_intersectionHitBuffer.SetData(m_intersectionHit);
 
-            Matrix4x4 worldToLocal = transform.worldToLocalMatrix;
-            Vector3 centerLocal = worldToLocal.MultiplyPoint3x4(centerWorld);
-            float radiusLocal = Mathf.Max(
-                worldToLocal.MultiplyVector(Vector3.right * radiusWorld).magnitude,
+            Matrix4x4 localToWorld = transform.localToWorldMatrix;
+            float maxObjectScale = Mathf.Max(
+                localToWorld.MultiplyVector(Vector3.right).magnitude,
                 Mathf.Max(
-                    worldToLocal.MultiplyVector(Vector3.up * radiusWorld).magnitude,
-                    worldToLocal.MultiplyVector(Vector3.forward * radiusWorld).magnitude));
+                    localToWorld.MultiplyVector(Vector3.up).magnitude,
+                    localToWorld.MultiplyVector(Vector3.forward).magnitude));
 
             cs.SetInt(k_splatCount, (int)m_remainingCount);
-            cs.SetVector(k_sphereCenter, centerLocal);
-            cs.SetFloat(k_sphereRadius, radiusLocal);
+            cs.SetVector(k_sphereCenter, centerWorld);
+            cs.SetFloat(k_sphereRadius, radiusWorld);
             cs.SetFloat(k_scaleFactor, scaleFactor);
+            cs.SetFloat(k_maxObjectScale, maxObjectScale);
+            cs.SetMatrix(k_matrixM, localToWorld);
             cs.SetBuffer(kernel, k_hitBuffer, m_intersectionHitBuffer);
             cs.Dispatch(kernel, (int)GsplatUtils.DivRoundUp(m_remainingCount, 256), 1, 1);
 

--- a/Runtime/GsplatRendererImpl.cs
+++ b/Runtime/GsplatRendererImpl.cs
@@ -32,6 +32,7 @@ namespace Gsplat
         static readonly int k_packedSplatsBuffer = Shader.PropertyToID("_PackedSplatsBuffer");
         static readonly int k_positionBuffer = Shader.PropertyToID("_PositionBuffer");
         static readonly int k_scaleBuffer = Shader.PropertyToID("_ScaleBuffer");
+        static readonly int k_colorBuffer = Shader.PropertyToID("_ColorBuffer");
         static readonly int k_matrixM = Shader.PropertyToID("_MATRIX_M");
         static readonly int k_splatInstanceSize = Shader.PropertyToID("_SplatInstanceSize");
         static readonly int k_splatCount = Shader.PropertyToID("_SplatCount");
@@ -92,6 +93,7 @@ namespace Gsplat
                 kernel = cs.FindKernel("IntersectUncompressed");
                 cs.SetBuffer(kernel, k_positionBuffer, uncompressed.PositionBuffer);
                 cs.SetBuffer(kernel, k_scaleBuffer, uncompressed.ScaleBuffer);
+                cs.SetBuffer(kernel, k_colorBuffer, uncompressed.ColorBuffer);
             }
             else
             {

--- a/Runtime/GsplatSettings.cs
+++ b/Runtime/GsplatSettings.cs
@@ -68,6 +68,7 @@ namespace Gsplat
         }
 
         public ComputeShader ComputeShader;
+        public ComputeShader IntersectionShader;
         public GsplatGlobalMaterial GlobalMaterial;
 
         [Tooltip(
@@ -113,6 +114,9 @@ namespace Gsplat
         static GsplatGlobalMaterial DefaultGlobalMaterial => AssetDatabase.LoadAssetAtPath<GsplatGlobalMaterial>(
             GsplatUtils.k_PackagePath + "Runtime/Materials/GsplatGlobal.asset");
 
+        static ComputeShader DefaultIntersectionShader => AssetDatabase.LoadAssetAtPath<ComputeShader>(
+            GsplatUtils.k_PackagePath + "Runtime/Shaders/GsplatIntersect.compute");
+
         static GsplatMaterial[] DefaultMaterials
         {
             get
@@ -132,6 +136,7 @@ namespace Gsplat
         {
             Version = GsplatUtils.k_Version;
             ComputeShader = DefaultComputeShader;
+            IntersectionShader = DefaultIntersectionShader;
             GlobalMaterial = DefaultGlobalMaterial;
             Materials = DefaultMaterials;
             SplatInstanceSize = 128;
@@ -177,6 +182,13 @@ namespace Gsplat
 
         void OnValidate()
         {
+#if UNITY_EDITOR
+            if (!IntersectionShader)
+            {
+                IntersectionShader = DefaultIntersectionShader;
+                EditorUtility.SetDirty(this);
+            }
+#endif
             if (ComputeShader != m_prevComputeShader)
             {
                 GsplatSorter.Instance.InitSorter(ComputeShader);

--- a/Runtime/Shaders/GsplatIntersect.compute
+++ b/Runtime/Shaders/GsplatIntersect.compute
@@ -8,6 +8,8 @@ uint _SplatCount;
 float3 _SphereCenter;
 float _SphereRadius;
 float _ScaleFactor;
+float _MaxObjectScale;
+float4x4 _MATRIX_M;
 
 StructuredBuffer<uint4> _PackedSplatsBuffer;
 StructuredBuffer<float3> _PositionBuffer;
@@ -44,7 +46,8 @@ bool IntersectsSplatSphere(float3 center, float3 scale, float alpha)
     if (alpha <= 0.0)
         return false;
 
-    float splatRadius = max(max(scale.x, scale.y), scale.z) * _ScaleFactor * 2.0;
+    center = mul(_MATRIX_M, float4(center, 1.0)).xyz;
+    float splatRadius = max(max(scale.x, scale.y), scale.z) * _ScaleFactor * 2.0 * _MaxObjectScale;
     float radius = _SphereRadius + splatRadius;
     return dot(center - _SphereCenter, center - _SphereCenter) <= radius * radius;
 }

--- a/Runtime/Shaders/GsplatIntersect.compute
+++ b/Runtime/Shaders/GsplatIntersect.compute
@@ -12,6 +12,7 @@ float _ScaleFactor;
 StructuredBuffer<uint4> _PackedSplatsBuffer;
 StructuredBuffer<float3> _PositionBuffer;
 StructuredBuffer<float3> _ScaleBuffer;
+StructuredBuffer<float4> _ColorBuffer;
 StructuredBuffer<uint> _OrderBuffer;
 RWStructuredBuffer<uint> _HitBuffer;
 
@@ -73,6 +74,6 @@ void IntersectUncompressed(uint3 id : SV_DispatchThreadID)
         return;
     uint idx = _OrderBuffer[orderIdx];
 
-    if (IntersectsSplatSphere(_PositionBuffer[idx], _ScaleBuffer[idx], 1.0))
+    if (IntersectsSplatSphere(_PositionBuffer[idx], _ScaleBuffer[idx], _ColorBuffer[idx].a))
         InterlockedAdd(_HitBuffer[0], 1);
 }

--- a/Runtime/Shaders/GsplatIntersect.compute
+++ b/Runtime/Shaders/GsplatIntersect.compute
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Yize Wu
+// SPDX-License-Identifier: MIT
+
+#pragma kernel IntersectSpark
+#pragma kernel IntersectUncompressed
+
+uint _SplatCount;
+float3 _SphereCenter;
+float _SphereRadius;
+float _ScaleFactor;
+
+StructuredBuffer<uint4> _PackedSplatsBuffer;
+StructuredBuffer<float3> _PositionBuffer;
+StructuredBuffer<float3> _ScaleBuffer;
+RWStructuredBuffer<uint> _HitBuffer;
+
+static const float LN_SCALE_MIN = -12.0;
+static const float LN_SCALE_MAX = 9.0;
+
+void UnpackSparkSplat(uint4 packedData, out float alpha, out float3 center, out float3 scale)
+{
+    uint word0 = packedData.x;
+    uint word1 = packedData.y;
+    uint word2 = packedData.z;
+    uint word3 = packedData.w;
+
+    alpha = float((word0 >> 24u) & 0xFFU) / 255.0;
+    center = float3(f16tof32(word1 & 0xFFFFU), f16tof32((word1 >> 16u) & 0xFFFFU),
+        f16tof32(word2 & 0xFFFFU));
+
+    uint3 uScale = uint3(word3 & 0xFFU, (word3 >> 8u) & 0xFFU, (word3 >> 16u) & 0xFFU);
+    float lnScaleScale = (LN_SCALE_MAX - LN_SCALE_MIN) / 254.0;
+    scale = float3(
+        (uScale.x == 0u) ? 0.0 : exp(LN_SCALE_MIN + float(uScale.x - 1u) * lnScaleScale),
+        (uScale.y == 0u) ? 0.0 : exp(LN_SCALE_MIN + float(uScale.y - 1u) * lnScaleScale),
+        (uScale.z == 0u) ? 0.0 : exp(LN_SCALE_MIN + float(uScale.z - 1u) * lnScaleScale)
+    );
+}
+
+bool IntersectsSplatSphere(float3 center, float3 scale, float alpha)
+{
+    if (alpha <= 0.0)
+        return false;
+
+    float splatRadius = max(max(scale.x, scale.y), scale.z) * _ScaleFactor * 2.0;
+    float radius = _SphereRadius + splatRadius;
+    return dot(center - _SphereCenter, center - _SphereCenter) <= radius * radius;
+}
+
+[numthreads(256, 1, 1)]
+void IntersectSpark(uint3 id : SV_DispatchThreadID)
+{
+    uint idx = id.x;
+    if (idx >= _SplatCount || _HitBuffer[0] != 0)
+        return;
+
+    float alpha;
+    float3 center;
+    float3 scale;
+    UnpackSparkSplat(_PackedSplatsBuffer[idx], alpha, center, scale);
+
+    if (IntersectsSplatSphere(center, scale, alpha))
+        InterlockedAdd(_HitBuffer[0], 1);
+}
+
+[numthreads(256, 1, 1)]
+void IntersectUncompressed(uint3 id : SV_DispatchThreadID)
+{
+    uint idx = id.x;
+    if (idx >= _SplatCount || _HitBuffer[0] != 0)
+        return;
+
+    if (IntersectsSplatSphere(_PositionBuffer[idx], _ScaleBuffer[idx], 1.0))
+        InterlockedAdd(_HitBuffer[0], 1);
+}

--- a/Runtime/Shaders/GsplatIntersect.compute
+++ b/Runtime/Shaders/GsplatIntersect.compute
@@ -12,6 +12,7 @@ float _ScaleFactor;
 StructuredBuffer<uint4> _PackedSplatsBuffer;
 StructuredBuffer<float3> _PositionBuffer;
 StructuredBuffer<float3> _ScaleBuffer;
+StructuredBuffer<uint> _OrderBuffer;
 RWStructuredBuffer<uint> _HitBuffer;
 
 static const float LN_SCALE_MIN = -12.0;
@@ -50,9 +51,10 @@ bool IntersectsSplatSphere(float3 center, float3 scale, float alpha)
 [numthreads(256, 1, 1)]
 void IntersectSpark(uint3 id : SV_DispatchThreadID)
 {
-    uint idx = id.x;
-    if (idx >= _SplatCount || _HitBuffer[0] != 0)
+    uint orderIdx = id.x;
+    if (orderIdx >= _SplatCount || _HitBuffer[0] != 0)
         return;
+    uint idx = _OrderBuffer[orderIdx];
 
     float alpha;
     float3 center;
@@ -66,9 +68,10 @@ void IntersectSpark(uint3 id : SV_DispatchThreadID)
 [numthreads(256, 1, 1)]
 void IntersectUncompressed(uint3 id : SV_DispatchThreadID)
 {
-    uint idx = id.x;
-    if (idx >= _SplatCount || _HitBuffer[0] != 0)
+    uint orderIdx = id.x;
+    if (orderIdx >= _SplatCount || _HitBuffer[0] != 0)
         return;
+    uint idx = _OrderBuffer[orderIdx];
 
     if (IntersectsSplatSphere(_PositionBuffer[idx], _ScaleBuffer[idx], 1.0))
         InterlockedAdd(_HitBuffer[0], 1);

--- a/Runtime/Shaders/GsplatIntersect.compute.meta
+++ b/Runtime/Shaders/GsplatIntersect.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c42c1f524804e47a50f194942e0ab31
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds a runtime sphere-intersection query to `GsplatRenderer`. It is intended
for tools that need to determine whether a world-space sphere overlaps any uploaded
splat, such as selection widgets or spatial interaction tools.

The query transforms the sphere into renderer-local space, dispatches a compute
shader over the uploaded splats, and reads back a one-element hit buffer. Both Spark
and Uncompressed GPU resource layouts are supported.

### Public API

```csharp
bool TryIntersectSphere(Vector3 centerWorld, float radiusWorld, out float score)
```

The method returns `true` when at least one splat intersects the sphere. The current
implementation returns a binary score of `1.0` for a hit and leaves the score at
`-1.0` when there is no hit or the renderer cannot be queried.

### Main changes

- Add `GsplatRenderer.TryIntersectSphere`.
- Add Spark and Uncompressed intersection kernels.
- Account for renderer transforms, non-uniform scale, splat scale, and the renderer's
  splat downscale factor.
- Add and dispose a reusable one-element GPU hit buffer.
- Add the intersection compute shader to `GsplatSettings` defaults.

### Risk and performance

The method performs a synchronous GPU readback through `GraphicsBuffer.GetData`.
Calling it frequently or once per renderer every frame can stall the CPU waiting for
the GPU. The intended use should therefore be occasional interaction queries unless
the implementation is later converted to asynchronous readback or batching.

The returned score is currently binary rather than a distance or overlap measure.

### Suggested testing

- Test hits and misses with Spark and Uncompressed assets.
- Test translated, rotated, uniformly scaled, and non-uniformly scaled renderers.
- Test partially uploaded assets and renderers with no uploaded splats.
- Test the effect of `SplatDownscaleFactor`.
- Profile repeated calls to document the synchronous readback cost.



