### PR TITLE
Fix Unity 6.4 Object ID compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed PLY header parsing to count only vertex element properties. The package now supports PLY files exported by Apple's [ml-sharp](https://github.com/apple/ml-sharp). ([#33](https://github.com/wuyize25/gsplat-unity/pull/33) by [@TakashiYoshinaga](https://github.com/TakashiYoshinaga))
 
+- Fixed compilation errors on Unity 6.4 and later caused by the obsoletion of `Object.GetInstanceID()`, while preserving compatibility with older Unity versions.
+
 ## [1.3.0] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed PLY header parsing to count only vertex element properties. The package now supports PLY files exported by Apple's [ml-sharp](https://github.com/apple/ml-sharp). ([#33](https://github.com/wuyize25/gsplat-unity/pull/33) by [@TakashiYoshinaga](https://github.com/TakashiYoshinaga))
 
-- Fixed compilation errors on Unity 6.4 and later caused by the obsoletion of `Object.GetInstanceID()`, while preserving compatibility with older Unity versions.
+- Fixed compilation errors on Unity 6.4 and later caused by the obsoletion of `Object.GetInstanceID()`, while preserving compatibility with older Unity versions. ([#41](https://github.com/wuyize25/gsplat-unity/pull/41) by [@RuiCarvalhoCouto](https://github.com/RuiCarvalhoCouto))
 
 ## [1.3.0] - 2026-05-23
 

--- a/Runtime/GsplatRendererImpl.cs
+++ b/Runtime/GsplatRendererImpl.cs
@@ -17,7 +17,7 @@ namespace Gsplat
         GsplatAsset m_gsplatAsset;
         public uint m_remainingCount = 0;
         public Bounds m_bounds;
-        int m_gsplatAssetID;
+        ulong m_gsplatAssetID;
 
         public GsplatResource GsplatResource;
         public GraphicsBuffer OrderBuffer { get; private set; }
@@ -39,7 +39,7 @@ namespace Gsplat
         uint m_sortsBeforeRecomputeCutouts = 0;
         public bool ComputeSortRequired = true;
         public bool ComputeCutoutsRequired = true;
-        Dictionary<int, (Vector3, Vector3)> m_prevCamTransforms;
+        Dictionary<ulong, (Vector3, Vector3)> m_prevCamTransforms;
 
         GsplatCutout.ShaderData[] m_cutoutsData;
         uint m_prevSplatCount;
@@ -47,7 +47,7 @@ namespace Gsplat
         public GsplatRendererImpl(uint splatCount)
         {
             SplatCount = splatCount;
-            m_prevCamTransforms = new Dictionary<int, (Vector3, Vector3)>();
+            m_prevCamTransforms = new Dictionary<ulong, (Vector3, Vector3)>();
             CreateResources(splatCount);
             CreatePropertyBlock();
         }
@@ -134,7 +134,7 @@ namespace Gsplat
         public void BindGsplatAsset(GsplatAsset gsplatAsset, bool asyncUpload = false)
         {
             Debug.Assert(m_gsplatAssetID == 0);
-            m_gsplatAssetID = gsplatAsset.GetInstanceID();
+            m_gsplatAssetID = GsplatUtils.GetObjectId(gsplatAsset);
             m_gsplatAsset = gsplatAsset;
             GsplatResource = GsplatResourceManager.Get(gsplatAsset);
             gsplatAsset.SetupMaterialPropertyBlock(m_propertyBlock, GsplatResource);
@@ -193,7 +193,7 @@ namespace Gsplat
         {
             foreach (var cam in Camera.allCameras)
             {
-                var id = cam.GetInstanceID();
+                var id = GsplatUtils.GetObjectId(cam);
                 if (m_prevCamTransforms.TryGetValue(id, out (Vector3, Vector3) prevCamTransform))
                 {
                     (Vector3 prevCamPos, Vector3 prevCamRot) = prevCamTransform;
@@ -209,7 +209,7 @@ namespace Gsplat
                 }
                 else
                 {
-                    m_prevCamTransforms.Add(cam.GetInstanceID(), (cam.transform.position, cam.transform.eulerAngles));
+                    m_prevCamTransforms.Add(id, (cam.transform.position, cam.transform.eulerAngles));
                     ForceRefresh();
                 }
             }

--- a/Runtime/GsplatResourceManager.cs
+++ b/Runtime/GsplatResourceManager.cs
@@ -11,11 +11,11 @@ namespace Gsplat
             public int RefCount;
         }
 
-        static readonly Dictionary<int, Cache> k_resourceCache = new();
+        static readonly Dictionary<ulong, Cache> k_resourceCache = new();
 
         public static GsplatResource Get(GsplatAsset asset)
         {
-            var key = asset.GetInstanceID();
+            var key = GsplatUtils.GetObjectId(asset);
             if (k_resourceCache.TryGetValue(key, out var cache))
             {
                 cache.RefCount++;
@@ -33,14 +33,19 @@ namespace Gsplat
 
         public static void Release(GsplatAsset asset)
         {
-            Release(asset.GetInstanceID());
+            Release(GsplatUtils.GetObjectId(asset));
         }
 
         public static void Release(int instanceID)
         {
-            if (instanceID == 0)
+            Release(unchecked((uint)instanceID));
+        }
+
+        internal static void Release(ulong objectID)
+        {
+            if (objectID == 0)
                 return;
-            if (!k_resourceCache.TryGetValue(instanceID, out var cache))
+            if (!k_resourceCache.TryGetValue(objectID, out var cache))
             {
                 Debug.LogWarning("Trying to release a GPU resource that is not cached.");
                 return;
@@ -49,7 +54,7 @@ namespace Gsplat
             cache.RefCount--;
             if (cache.RefCount != 0) return;
             cache.Resource.Dispose();
-            k_resourceCache.Remove(instanceID);
+            k_resourceCache.Remove(objectID);
         }
     }
 }

--- a/Runtime/GsplatSorter.cs
+++ b/Runtime/GsplatSorter.cs
@@ -68,7 +68,7 @@ namespace Gsplat
         readonly HashSet<IGsplat> m_gsplats = new();
         readonly HashSet<Camera> m_camerasInjected = new();
         readonly List<IGsplat> m_activeGsplats = new();
-        readonly HashSet<int> m_warnedUncompressed = new();
+        readonly HashSet<ulong> m_warnedUncompressed = new();
         GsplatSortPass m_sortPass;
         public const string k_passName = "SortGsplats";
         const string k_depthPassName = "Gsplat.ComputeDepth";
@@ -109,7 +109,7 @@ namespace Gsplat
                 return;
 
             if (gsplat is UnityEngine.Object obj)
-                m_warnedUncompressed.Remove(obj.GetInstanceID());
+                m_warnedUncompressed.Remove(GsplatUtils.GetObjectId(obj));
 
             m_globalRenderer.MarkGlobalBuffersDirty();
 
@@ -158,7 +158,7 @@ namespace Gsplat
             {
                 if (gs.GsplatResource is GsplatResourceSpark) continue;
                 var obj = gs as UnityEngine.Object;
-                var id = obj ? obj.GetInstanceID() : 0;
+                var id = obj ? GsplatUtils.GetObjectId(obj) : 0;
                 if (m_warnedUncompressed.Add(id))
                     Debug.LogWarning(
                         $"[GsplatSorter] '{obj?.name}' uses an uncompressed asset; global sort requires every active renderer to use SPARK compression. Disabling global sort for this scene — all renderers fall back to per-renderer rendering.");

--- a/Runtime/GsplatUtils.cs
+++ b/Runtime/GsplatUtils.cs
@@ -12,6 +12,15 @@ namespace Gsplat
         public const string k_PackagePath = "Packages/wu.yize.gsplat/";
         public static readonly Version k_Version = new("1.4.0");
 
+        internal static ulong GetObjectId(UnityEngine.Object obj)
+        {
+#if UNITY_6000_4_OR_NEWER
+            return EntityId.ToULong(obj.GetEntityId());
+#else
+            return unchecked((uint)obj.GetInstanceID());
+#endif
+        }
+
         // radix sort etc. friendly, see http://stereopsis.com/radix.html
         public static uint FloatToSortableUint(float f)
         {


### PR DESCRIPTION
  ## Summary

  - Fixes CS0619 compilation errors on Unity 6.4 and later.
  - Uses `Object.GetEntityId()` on Unity 6.4+.
  - Retains `Object.GetInstanceID()` on older supported Unity versions.
  - Preserves the existing `GsplatResourceManager.Release(int)` public API.
  - Stores internal object identifiers as `ulong` so both APIs share a common key type.

## Testing

- [x] Imported a model of 10M Gaussians & SH2.
- [x] Rendered a model of 10M Gaussians & SH2 on Unity 6.3 LFS, in Play Mode and in Scene Mode.
- [x] Rendered a model of 10M Gaussians & SH2 on Unity 6.5, in Play Mode and in Scene Mode.
- [x] Check if SH3 and SH4 are rendering correctly.